### PR TITLE
ReduceClutterParameters

### DIFF
--- a/rsHRF/parameters.py
+++ b/rsHRF/parameters.py
@@ -41,5 +41,7 @@ def wgr_get_parameters(hdrf, dt):
         param[2] = w * dt
 
     else:
-        print(".")
+        warnings.warn(
+            "Empty or zero time course for voxel (probably masked).", RuntimeWarning
+        )
     return param.ravel()

--- a/rsHRF/parameters.py
+++ b/rsHRF/parameters.py
@@ -14,7 +14,7 @@ def wgr_get_parameters(hdrf, dt):
     param = np.zeros((3, 1))
 
     if np.any(hdrf):
-        n = np.fix(np.amax(hdrf.shape) * 0.8)
+        n = np.trunc(np.amax(hdrf.shape) * 0.8)
 
         p = np.argmax(np.absolute(hdrf[np.arange(0, n, dtype="int")]))
         h = hdrf[p]


### PR DESCRIPTION
Whenever a previous preprocessing step used a mask tighter than the one employed by rsHRF, there would be possibly many voxels with a null time course. For each of them rsHRF would print out a dot (".") to stdout making it unusable to check the progress.

Issuing a warning should be the appropriate way to deal with these cases, however it clashes with a policy established long ago (commit: 5e3286bb06c1292acbf8fa1f83bfb27c0ce7b34e) of ignoring all warnings.