### PR TITLE
Improve CLI help text and usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,28 +52,30 @@ https://bids-apps.neuroimaging.io/rsHRF/
 
 You can run rsHRF as a containerized BIDS App using Docker. This avoids the need to install Python dependencies locally and ensures reproducibility.
 
-### 1. Pull the latest image:
+### 1. Pull the current development image:
+
 ```bash
 docker pull bids/rshrf:unstable
 ```
+
 ### 2. Run the analysis:
 
-To run the analysis on a BIDS-formatted dataset, use the following command structure:
+To run the analysis on a BIDS derivative dataset, such as an fMRIPrep derivatives directory, use the BIDS Apps-style command structure:
 
 ```bash
 docker run -ti --rm \
-  -v /path/to/your/bids_dataset:/data:ro \
+  -v /path/to/your/bids_derivative_dataset:/data:ro \
   -v /path/to/your/output_dir:/out \
   bids/rshrf:unstable \
-  --bids_dir /data \
-  --output_dir /out \
-  --analysis_level participant \
-  --participant_label 01 \
-  --brainmask \
-  --estimation canon2dd \
-  --wiener
-
+  /data \
+  /out \
+  participant \
+  --participant-label 01 \
+  -m BIDS \
+  --estimation canon2dd
 ```
+
+Here, `/data` should point to the BIDS derivative dataset containing files such as `dataset_description.json`, preprocessed BOLD images, and brain masks. The participant label should be provided without the `sub-` prefix.
 
 **References**
 --------

--- a/rsHRF/CLI.py
+++ b/rsHRF/CLI.py
@@ -2,7 +2,7 @@ import sys
 import numpy as np
 import os.path as op
 import json
-from argparse import ArgumentParser
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from bids.layout import BIDSLayout
 from bids.config import set_option
 from pathlib import Path
@@ -20,16 +20,35 @@ with open(op.join(op.dirname(op.realpath(__file__)), "VERSION"), "r") as fh:
 
 def get_parser():
     parser = ArgumentParser(
-        description="retrieves the onsets of pseudo-events triggering a "
-        "haemodynamic response from resting state fMRI BOLD "
-        "voxel-wise signal"
+        description=(
+            "Estimate resting-state hemodynamic response functions (HRFs) "
+            "and optionally deconvolve BOLD signals."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  BIDS derivative input:\n"
+            "    rsHRF /path/to/fmriprep /path/to/output participant "
+            "--participant-label 0001 -m BIDS --estimation canon2dd\n\n"
+            "  Non-BIDS NIfTI/GIfTI input:\n"
+            "    rsHRF /path/to/bold.nii.gz /path/to/output --no-bids "
+            "-m /path/to/mask.nii.gz --TR 2 --estimation canon2dd\n\n"
+            "  Text time-series input:\n"
+            "    rsHRF /path/to/timeseries.txt /path/to/output --no-bids "
+            "--TR 2 --estimation canon2dd\n\n"
+            "  GUI mode:\n"
+            "    rsHRF GUI --no-bids"
+        ),
+        formatter_class=RawDescriptionHelpFormatter,
     )
 
     parser.add_argument(
         "bids_dir",
-        help="the input data for the analysis: a path to a data file or the root "
-        "folder of a BIDS valid dataset, or 'GUI' to run in graphical user interface "
-        "mode",
+        help=(
+            "Input data. For BIDS mode, provide the root directory of a BIDS "
+            "derivative dataset, such as an fMRIPrep derivatives folder. For "
+            "non-BIDS mode, provide a NIfTI, GIfTI, or text time-series file. "
+            "Use 'GUI' with --no-bids to launch the graphical interface."
+        ),
         default="GUI",
     )
 
@@ -37,16 +56,16 @@ def get_parser():
         "output_dir",
         action="store",
         type=op.abspath,
-        help="the output path for the outcomes of processing",
+        help="Directory where rsHRF outputs will be written.",
         nargs="?",
     )
 
     parser.add_argument(
         "analysis_level",
-        help="Level of the analysis that will be performed. "
-        "Multiple participant level analyses can be run independently "
-        "(in parallel) using the same output_dir. Only 'participant' level analysis is"
-        " allowed.",
+        help=(
+            "BIDS analysis level. Only 'participant' is currently supported. "
+            "Required in BIDS mode and omitted in --no-bids mode."
+        ),
         choices=["participant"],
         nargs="?",
     )
@@ -54,8 +73,10 @@ def get_parser():
     parser.add_argument(
         "--no-bids",
         action="store_true",
-        help="Explicitly disable bids input. Necessary when using txt or nii/gii files"
-        " directly.",
+        help=(
+            "Disable BIDS parsing and run directly on a NIfTI, GIfTI, or text "
+            "time-series input file. Required for non-BIDS inputs and GUI mode."
+        ),
     )
 
     parser.add_argument(
@@ -63,8 +84,10 @@ def get_parser():
         action="store",
         type=int,
         default=-1,
-        help="the number of parallel processing elements to use, default is -1 (use "
-        "all available cores)",
+        help=(
+            "Number of parallel jobs to use. Default: -1, which uses all "
+            "available cores."
+        ),
     )
 
     parser.add_argument(
@@ -76,11 +99,12 @@ def get_parser():
 
     parser.add_argument(
         "--participant-label",
-        help="The label(s) of the participant(s) that should be analyzed. The label "
-        "corresponds to sub-<participant_label> from the BIDS spec "
-        '(so it does not include "sub-"). If this parameter is not '
-        "provided all subjects should be analyzed. Multiple "
-        "participants can be specified with a space separated list.",
+        help=(
+            "Participant label(s) to analyze in BIDS mode. Labels correspond "
+            "to sub-<label> but should be provided without the 'sub-' prefix. "
+            "If omitted, all available subjects are analyzed. Multiple labels "
+            "can be supplied as a space-separated list."
+        ),
         nargs="+",
     )
 
@@ -88,8 +112,10 @@ def get_parser():
         "--bids-filter-file",
         action="store",
         type=op.abspath,
-        help="a JSON file describing custom BIDS input filters using PyBIDS. "
-        "For further details, please check out http://bids-apps.neuroimaging.io/rsHRF/",
+        help=(
+            "JSON file with custom PyBIDS filters for selecting input files "
+            "from a BIDS derivative dataset."
+        ),
     )
 
     parser.add_argument(
@@ -97,9 +123,10 @@ def get_parser():
         "--mask",
         action="store",
         type=str,
-        help="the absolute path to a single mask file, which should be of the same "
-        "type as the input file (NIfTI or GIfTI). Use 'BIDS' to enable the use of "
-        "mask files present in the BIDS directory itself.",
+        help=(
+            "Mask source. Use 'BIDS' to use masks found in the BIDS derivative "
+            "dataset, or provide a path to a NIfTI/GIfTI mask matching the input."
+        ),
     )
 
     group_para = parser.add_argument_group("Parameters")
@@ -108,13 +135,13 @@ def get_parser():
         "--estimation",
         action="store",
         choices=available_estimations,
-        help="Choose the estimation procedure from "
-        "canon2dd (canonical shape with 2 derivatives), "
-        "sFIR (smoothed Finite Impulse Response), "
-        "FIR (Finite Impulse Response), "
-        "fourier (Fourier Basis Set), "
-        "hanning (Fourier Basis w Hanning), "
-        f"gamma (Gamma Basis Set).",
+        help=(
+            "HRF estimation model. Choices: canon2dd (canonical HRF with time "
+            "and dispersion derivatives), sFIR (smoothed finite impulse "
+            "response), FIR (finite impulse response), fourier (Fourier basis "
+            "set), hanning (Fourier basis with Hanning window), gamma (Gamma "
+            "basis set)."
+        ),
         default=default_parameters["estimation"],
     )
 
@@ -125,7 +152,10 @@ def get_parser():
         nargs=2,
         metavar=("LOW_FREQ", "HIGH_FREQ"),
         default=default_parameters["passband"],
-        help="set intervals for bandpass filter, default is 0.01 - 0.08",
+        help=(
+            "Temporal band-pass filter for the BOLD signal, given as LOW_FREQ "
+            "HIGH_FREQ in Hz. Default: 0.01 0.08."
+        ),
     )
 
     group_para.add_argument(
@@ -135,15 +165,20 @@ def get_parser():
         nargs=2,
         metavar=("LOW_FREQ", "HIGH_FREQ"),
         default=default_parameters["passband_deconvolve"],
-        help="set intervals for bandpass filter (used while deconvolving BOLD), "
-        "default is no-filtering",
+        help=(
+            "Temporal band-pass filter used during BOLD deconvolution, given "
+            "as LOW_FREQ HIGH_FREQ in Hz. Default: no filtering."
+        ),
     )
 
     group_para.add_argument(
         "--TR",
         action="store",
         type=float,
-        help="set TR parameter",
+        help=(
+            "Repetition time in seconds. Required for text inputs and used as "
+            "a fallback when TR cannot be read from image metadata."
+        ),
         default=default_parameters["TR"],
     )
 
@@ -152,7 +187,10 @@ def get_parser():
         "-T",
         action="store",
         type=int,
-        help=f"set T parameter, default is {default_parameters['T']}",
+        help=(
+            f"Microtime resolution factor; dt = TR / T. "
+            f"Default: {default_parameters['T']}"
+        ),
         default=default_parameters["T"],
     )
 
@@ -161,7 +199,10 @@ def get_parser():
         action="store",
         type=int,
         default=default_parameters["T0"],
-        help=f"set T0 parameter, default is {default_parameters['T0']}",
+        help=(
+            f"Reference microtime bin for onset estimation. "
+            f"Default: {default_parameters['T0']}"
+        ),
     )
 
     group_para.add_argument(
@@ -170,7 +211,10 @@ def get_parser():
         dest="TD_DD",
         type=int,
         default=default_parameters["TD_DD"],
-        help=f"set TD_DD parameter, default is {default_parameters['TD_DD']}",
+        help=(
+            "Derivative setting for the canonical HRF model. "
+            f"Default: {default_parameters['TD_DD']}"
+        ),
     )
 
     group_para.add_argument(
@@ -178,7 +222,10 @@ def get_parser():
         action="store",
         type=int,
         default=default_parameters["AR_lag"],
-        help=f"set AR_lag parameter, default is {default_parameters['AR_lag']}",
+        help=(
+            "Autoregressive model lag for serial correlation. "
+            f"Default: {default_parameters['AR_lag']}"
+        ),
     )
 
     group_para.add_argument(
@@ -187,7 +234,10 @@ def get_parser():
         action="store",
         type=float,
         default=default_parameters["thr"],
-        help=f"set thr parameter, default is {default_parameters['thr']}",
+        help=(
+            "Point-process event threshold, expressed as mean + threshold * "
+            f"standard deviation. Default: {default_parameters['thr']}"
+        ),
     )
 
     group_para.add_argument(
@@ -195,8 +245,11 @@ def get_parser():
         "--tmask",
         action="store",
         type=op.abspath,
-        help="the path for the (temporal) mask file.\n The mask file should be a text "
-        "file, a sequence of 0s and 1s of the same length as the signal",
+        help=(
+            "Path to a temporal mask text file used to exclude time points, "
+            "for example after scrubbing. The file should contain a sequence "
+            "of 0s and 1s with the same length as the signal."
+        ),
     )
 
     group_para.add_argument(
@@ -204,9 +257,10 @@ def get_parser():
         action="store",
         type=int,
         default=default_parameters["order"],
-        help=f"set the number of basis vectors, default is "
-        f"{default_parameters['order']} (used for fourier, hanning and gamma basis "
-        "functions)",
+        help=(
+            "Number of basis vectors used for fourier, hanning, and gamma "
+            f"basis functions. Default: {default_parameters['order']}"
+        ),
     )
 
     group_para.add_argument(
@@ -214,7 +268,7 @@ def get_parser():
         action="store",
         type=int,
         default=default_parameters["len"],
-        help=f"set len parameter, default is {default_parameters['len']}s",
+        help=f"HRF duration in seconds. Default: {default_parameters['len']}",
     )
 
     group_para.add_argument(
@@ -222,7 +276,10 @@ def get_parser():
         action="store",
         type=int,
         default=default_parameters["min_onset_search"],
-        help=f"set min_onset_search parameter, default is {default_parameters['min_onset_search']}s",
+        help=(
+            "Minimum event-to-HRF onset delay searched, in seconds. "
+            f"Default: {default_parameters['min_onset_search']}"
+        ),
     )
 
     group_para.add_argument(
@@ -230,21 +287,27 @@ def get_parser():
         action="store",
         type=int,
         default=default_parameters["max_onset_search"],
-        help=f"set max_onset_search parameter, default is {default_parameters['max_onset_search']}s",
+        help=(
+            "Maximum event-to-HRF onset delay searched, in seconds. "
+            f"Default: {default_parameters['max_onset_search']}"
+        ),
     )
 
     group_para.add_argument(
         "--localK",
         action="store",
         type=int,
-        help=f"set localK, default is {default_parameters['localK']}",
+        help=(
+            "Local peak width used for point-process event detection. "
+            f"Default: {default_parameters['localK']}"
+        ),
         default=default_parameters["localK"],
     )
 
     group_para.add_argument(
         "--wiener",
         action="store_true",
-        help="to perform iterative wiener deconvolution",
+        help="Run iterative Wiener deconvolution after HRF estimation.",
     )
 
     return parser

--- a/rsHRF/rsHRF_GUI/datatypes/misc/parameters.py
+++ b/rsHRF/rsHRF_GUI/datatypes/misc/parameters.py
@@ -36,7 +36,7 @@ class Parameters:
         return self.T
 
     def get_T0(self):
-        return self.get_T0
+        return self.T0
 
     def get_TD_DD(self):
         # TD_DD is only relevant for canon2dd estimation
@@ -46,21 +46,21 @@ class Parameters:
             return None
 
     def get_AR_lag(self):
-        return self.get_AR_lag
+        return self.AR_lag
 
     def get_thr(self):
         return self.thr
 
     def get_order(self):
         # order is only relevant for fourier and gamma estimation
-        if "gamma" in self.get_estimation or "fourier" in self.get_estimation:
+        if "gamma" in self.get_estimation() or "fourier" in self.get_estimation():
             return self.order
         else:
             return None
 
     def get_Volterra(self):
         # volterra is only relevant for canon2dd estimation
-        if self.get_estimation == "canon2dd":
+        if self.get_estimation() == "canon2dd":
             return self.volterra
         else:
             return None
@@ -414,7 +414,7 @@ class Parameters:
             elif key == "order":
                 out = self.set_order(dic[key])
             elif key == "Volterra":
-                out = self.set_thr(dic[key])
+                out = self.set_Volterra(dic[key])
             elif key == "len":
                 out = self.set_len(dic[key])
             elif key == "temporal_mask":

--- a/rsHRF/rsHRF_GUI/gui_windows/inputWindow.py
+++ b/rsHRF/rsHRF_GUI/gui_windows/inputWindow.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from tkinter import (
     Toplevel,
     Checkbutton,
@@ -11,7 +12,27 @@ from tkinter import (
     StringVar,
     Label,
 )
+
 from ...utils.default_parameters import available_estimations
+
+SUPPORTED_IMAGE_FILETYPES = [
+    ("NIfTI/GIfTI files", ("*.nii", "*.nii.gz", "*.gii", "*.gii.gz")),
+    ("All files", "*.*"),
+]
+
+
+def ask_image_filename(title):
+    kwargs = {
+        "initialdir": os.getcwd(),
+        "title": title,
+    }
+
+    # macOS/Tk can crash in the native file dialog when filetypes are passed.
+    # Keep filters on Windows/Linux, but omit them on macOS to keep the GUI usable.
+    if sys.platform != "darwin":
+        kwargs["filetypes"] = SUPPORTED_IMAGE_FILETYPES
+
+    return filedialog.askopenfilename(**kwargs)
 
 
 class InputWindow:
@@ -19,9 +40,11 @@ class InputWindow:
         # input window
         window = Toplevel()
         window.title("Input Window")
+
         # get screen width and height
         screen_width = window.winfo_screenwidth()
         screen_height = window.winfo_screenheight()
+
         # placing the toplevel
         window.geometry(
             "350x220+%d+%d"
@@ -30,18 +53,22 @@ class InputWindow:
                 ((((1040.0 - 220) / 1000) * screen_height) - 390) - 280,
             )
         )
+
         # variables which shall get sent to the front end
         self.input_file = ()
         self.mask_file = ()
         self.file_type = ()
         self.output_dir = ()
-        # other class vairables
+
+        # other class variables
         # 1 corresponds to BIDS input
         self.inputFormatVar = IntVar()
         self.inputFormatVar.set(0)
+
         # 1 corresponds to mask file being present in the BIDS directory
         self.maskFormatVar = IntVar()
         self.maskFormatVar.set(0)
+
         # selecting the estimation rule
         self.estimationOption = StringVar()
         self.estimationOption.set("canon2dd")
@@ -51,25 +78,17 @@ class InputWindow:
                 self.input_file = filedialog.askdirectory(initialdir=os.getcwd())
                 maskFormat.configure(state=NORMAL)
             else:
-                self.input_file = filedialog.askopenfilename(
-                    initialdir=os.getcwd(),
-                    title="Input File Path",
-                    filetypes=(
-                        ("nifti files", "*.nii"),
-                        ("nifti files", "*.nii.gz"),
-                        ("gifti files", "*.gii"),
-                        ("gifti files", "*.gii.gz"),
-                    ),
-                )
+                self.input_file = ask_image_filename("Input File Path")
                 maskFormat.configure(state=DISABLED)
                 try:
                     self.file_type = self.input_file.split(os.extsep, 1)[-1]
                     self.file_type = "." + self.file_type
-                except:
+                except Exception:
                     self.file_type = ()
+
             try:
                 inputFileLabel.configure(text=self.input_file.split("/")[-1])
-            except:
+            except Exception:
                 inputFileLabel.configure(text="")
 
         def maskFormatButtonState():
@@ -86,19 +105,10 @@ class InputWindow:
             maskFormatButtonState()
 
         def getMaskFile():
-            self.mask_file = filedialog.askopenfilename(
-                initialdir=os.getcwd(),
-                title="Input File Path",
-                filetypes=(
-                    ("nifti files", "*.nii"),
-                    ("nifti files", "*.nii.gz"),
-                    ("gifti files", "*.gii"),
-                    ("gifti files", "*.gii.gz"),
-                ),
-            )
+            self.mask_file = ask_image_filename("Mask File Path")
             try:
                 maskFileLabel.configure(text=self.mask_file.split("/")[-1])
-            except:
+            except Exception:
                 maskFileLabel.configure(text="")
 
         def getOutputDir():
@@ -107,7 +117,7 @@ class InputWindow:
                 outputPathLabel.configure(
                     text="Output path: " + self.output_dir.split("/")[-1]
                 )
-            except:
+            except Exception:
                 outputPathLabel.configure(text="")
 
         # defining widgets
@@ -125,7 +135,11 @@ class InputWindow:
             command=maskFormatButtonState,
         )
         inputFormatButton = Button(
-            window, text="Select Input", command=getInputFile, height=1, width=20
+            window,
+            text="Select Input",
+            command=getInputFile,
+            height=1,
+            width=20,
         )
         maskFormatButton = Button(
             window,
@@ -147,8 +161,11 @@ class InputWindow:
         maskFileLabel = Label(window, text="")
         outputPathLabel = Label(window, text="")
         estimationDropDown = OptionMenu(
-            window, self.estimationOption, *available_estimations
+            window,
+            self.estimationOption,
+            *available_estimations,
         )
+
         # placing widgets
         inputFormat.grid(row=0, column=0, padx=(5, 5), pady=(5, 5))
         inputFormatButton.grid(row=0, column=1, padx=(5, 5), pady=(5, 5))
@@ -168,6 +185,7 @@ class InputWindow:
             mode = "bids w/ atlas"
         else:
             mode = "file"
+
         return (
             self.input_file,
             self.mask_file,

--- a/rsHRF/utils/default_parameters.py
+++ b/rsHRF/utils/default_parameters.py
@@ -2,22 +2,53 @@ import numpy as np
 import sys
 
 default_parameters = {}
-default_parameters["estimation"] = "canon2dd"  # why?
-default_parameters["passband"] = [0.01, 0.08]  # why?
-default_parameters["passband_deconvolve"] = [0.0, sys.float_info.max]  # why?
+
+# Default estimation method: canonical HRF with time and dispersion derivatives.
+default_parameters["estimation"] = "canon2dd"
+
+# Temporal band-pass filter used for the BOLD signal.
+default_parameters["passband"] = [0.01, 0.08]
+
+# No additional band-pass filtering during deconvolution by default.
+default_parameters["passband_deconvolve"] = [0.0, sys.float_info.max]
+
+# TR is read from BIDS metadata when using BIDS input; non-BIDS users must provide it.
 default_parameters["TR"] = -1
-default_parameters["localK"] = 1  # why?
-default_parameters["T"] = 3  # why?
-default_parameters["T0"] = 1  # why?
-default_parameters["TD_DD"] = 2  # why?
-default_parameters["AR_lag"] = 1  # why?
-default_parameters["thr"] = 1  # why?
-default_parameters["order"] = 3  # why?
-default_parameters["volterra"] = 0  # why?
-default_parameters["len"] = 24  # why?
-default_parameters["temporal_mask"] = []  # why?
-default_parameters["min_onset_search"] = 4  # why?
-default_parameters["max_onset_search"] = 8  # why?
+
+# Local peak width used for point-process event detection.
+default_parameters["localK"] = 1
+
+# Microtime resolution factor; dt = TR / T.
+default_parameters["T"] = 3
+
+# Reference microtime bin for onset estimation.
+default_parameters["T0"] = 1
+
+# Use canonical HRF with time and dispersion derivatives by default.
+default_parameters["TD_DD"] = 2
+
+# AR(1) serial correlation model.
+default_parameters["AR_lag"] = 1
+
+# Event detection threshold: mean + thr * standard deviation.
+default_parameters["thr"] = 1
+
+# Number of basis functions for gamma/fourier/hanning models.
+default_parameters["order"] = 3
+
+# Volterra expansion is disabled by default.
+default_parameters["volterra"] = 0
+
+# HRF duration in seconds.
+default_parameters["len"] = 24
+
+# Empty temporal mask: no events are excluded by default.
+default_parameters["temporal_mask"] = []
+
+# Minimum and maximum event-to-HRF onset delay in seconds.
+default_parameters["min_onset_search"] = 4
+default_parameters["max_onset_search"] = 8
+
 default_parameters["wiener"] = False
 default_parameters["dt"] = -1
 default_parameters["lag"] = np.arange(


### PR DESCRIPTION
Follow up cleanup after Giulio's CLI revamp in #27.

Changes:
- improve `rsHRF --help` text and examples
- update README Docker usage to the new BIDS Apps-style CLI
- clarify default parameter comments
- fix small GUI parameter accessor issues
- fix macOS GUI file picker crash while keeping file filters on non-macOS platforms

Tested:
- `pytest rsHRF/unit_tests/ -p no:warnings` → 57 passed
- real non-BIDS NIfTI + mask run
- real BIDS derivative run
- GUI smoke test