### PR TITLE
Fix: read the env var the guard actually checks in bids.py

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* `[Fixed]` `write_derivative_description` raised `KeyError` when `RSHRF_DOCKER_TAG` was set, and wrote
+  `"URI": null` when `RSHRF_SINGULARITY_URL` was set. Both branches now read the variable they gate on.
+* `[Fixed]` `write_derivative_description` no longer prints the version string to stdout.
+
 # rsHRF 1.5.8
 ## 12th September, 2021
 * `[Fixed]` Fixed bugs for rest_filter (was only estimating the first 5000 voxels.)

--- a/rsHRF/unit_tests/test_bids.py
+++ b/rsHRF/unit_tests/test_bids.py
@@ -1,0 +1,66 @@
+import io
+import json
+import contextlib
+
+import pytest
+
+from rsHRF.utils import bids
+
+ENV_KEYS = [
+    "RSHRF_DOCKER_TAG",
+    "RSHRF_SINGULARITY_URL",
+    "FMRIPREP_DOCKER_TAG",
+    "FMRIPREP_SINGULARITY_URL",
+]
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for key in ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _write(tmp_path):
+    src = tmp_path / "src"
+    deriv = tmp_path / "deriv"
+    src.mkdir()
+    deriv.mkdir()
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+        bids.write_derivative_description(src, deriv)
+    desc = json.loads((deriv / "dataset_description.json").read_text())
+    return desc, stdout.getvalue()
+
+
+def test_docker_tag_reads_its_own_env_var(clean_env, monkeypatch, tmp_path):
+    """Guard checks RSHRF_DOCKER_TAG, so the body must read it too (was KeyError)."""
+    monkeypatch.setenv("RSHRF_DOCKER_TAG", "1.7.0")
+    desc, _ = _write(tmp_path)
+    container = desc["GeneratedBy"][0]["Container"]
+    assert container["Type"] == "docker"
+    assert container["Tag"] == "bids/rshrf:1.7.0"
+
+
+def test_singularity_uri_is_never_null(clean_env, monkeypatch, tmp_path):
+    """The singularity branch used to getenv() a variable it never gated on."""
+    monkeypatch.setenv("RSHRF_SINGULARITY_URL", "shub://BIDS-Apps/rsHRF")
+    desc, _ = _write(tmp_path)
+    container = desc["GeneratedBy"][0]["Container"]
+    assert container["Type"] == "singularity"
+    assert container["URI"] == "shub://BIDS-Apps/rsHRF"
+
+
+def test_no_container_key_without_env(clean_env, tmp_path):
+    desc, _ = _write(tmp_path)
+    assert "Container" not in desc["GeneratedBy"][0]
+
+
+def test_writes_no_stdout(clean_env, tmp_path):
+    """A library function must not print; it used to emit the version string."""
+    _, stdout = _write(tmp_path)
+    assert stdout == ""
+
+
+def test_dataset_type_is_the_bids_key(clean_env, tmp_path):
+    desc, _ = _write(tmp_path)
+    assert desc["DatasetType"] == "derivative"

--- a/rsHRF/utils/bids.py
+++ b/rsHRF/utils/bids.py
@@ -1,7 +1,6 @@
 """Utilities to handle BIDS inputs."""
 
 import os
-import sys
 import json
 from pathlib import Path
 
@@ -9,7 +8,6 @@ from pathlib import Path
 def write_derivative_description(bids_dir, deriv_dir):
     from ..__about__ import __version__, DOWNLOAD_URL
 
-    print(__version__)
     bids_dir = Path(bids_dir)
     deriv_dir = Path(deriv_dir)
     desc = {
@@ -30,12 +28,12 @@ def write_derivative_description(bids_dir, deriv_dir):
     if "RSHRF_DOCKER_TAG" in os.environ:
         desc["GeneratedBy"][0]["Container"] = {
             "Type": "docker",
-            "Tag": f"bids/rshrf:{os.environ['FMRIPREP_DOCKER_TAG']}",
+            "Tag": f"bids/rshrf:{os.environ['RSHRF_DOCKER_TAG']}",
         }
     if "RSHRF_SINGULARITY_URL" in os.environ:
         desc["GeneratedBy"][0]["Container"] = {
             "Type": "singularity",
-            "URI": os.getenv("FMRIPREP_SINGULARITY_URL"),
+            "URI": os.environ["RSHRF_SINGULARITY_URL"],
         }
 
     # Keys deriving from source dataset


### PR DESCRIPTION
* RSHRF_DOCKER_TAG was guarded but FMRIPREP_DOCKER_TAG was read -> KeyError
* singularity branch wrote "URI": null for the same reason
* drop a stray print() and an unused import