### PR TITLE
Fix: spm_detrend crashed for polynomial order > 0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,7 @@
 * `[Added]` Standalone time-series input (.txt).
 * `[Added]` Implicit generation of brain-mask.
 * `[Fixed]` Minor bugs, raising appropriate errors, etc.
+* `[Fixed]` `spm_detrend` raised `TypeError` for polynomial order > 0.
 
 # rsHRF 1.1.1
 ## 24th July, 2020

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * `[Fixed]` `write_derivative_description` raised `KeyError` when `RSHRF_DOCKER_TAG` was set, and wrote
   `"URI": null` when `RSHRF_SINGULARITY_URL` was set. Both branches now read the variable they gate on.
 * `[Fixed]` `write_derivative_description` no longer prints the version string to stdout.
+* `[Fixed]` `spm_detrend` raised `TypeError` for polynomial order > 0.
 
 # rsHRF 1.5.8
 ## 12th September, 2021
@@ -50,7 +51,6 @@
 * `[Added]` Standalone time-series input (.txt).
 * `[Added]` Implicit generation of brain-mask.
 * `[Fixed]` Minor bugs, raising appropriate errors, etc.
-* `[Fixed]` `spm_detrend` raised `TypeError` for polynomial order > 0.
 
 # rsHRF 1.1.1
 ## 24th July, 2020

--- a/rsHRF/spm_dep/spm.py
+++ b/rsHRF/spm_dep/spm.py
@@ -129,7 +129,7 @@ def spm_detrend(x, p=0):
     G = np.zeros((m, p + 1))
     for i in range(0, p + 1):
         d = np.arange(1, m + 1) ** i
-        G[:, i] = d.flatten(1)
+        G[:, i] = d
     y = x - G.dot(np.linalg.pinv(G).dot(x))
     return y
 

--- a/rsHRF/unit_tests/test_spm.py
+++ b/rsHRF/unit_tests/test_spm.py
@@ -102,3 +102,29 @@ def test_spm_write_vol():
                 file_type = ".gii"
             assert os.path.isfile(fname + file_type)
             os.remove(fname + file_type)
+
+
+def test_spm_detrend_removes_polynomial_trend():
+    """p > 0 was unreachable: d.flatten(1) raised TypeError on modern NumPy."""
+    m = 20
+    t = np.arange(1, m + 1)
+    for p in (1, 2, 3):
+        # columns that are exactly degree-p polynomials in t
+        x = np.column_stack(
+            [
+                np.polyval(np.polyfit(t, 2.0 + 0.5 * t + 0.01 * t**2, p), t),
+                np.polyval(np.polyfit(t, -1.0 + 0.2 * t - 0.001 * t**3, p), t),
+            ]
+        )
+        y = spm.spm_detrend(x, p)
+        assert y.shape == x.shape
+        # an exact polynomial of degree p must be removed entirely
+        assert np.allclose(y, 0.0, atol=1e-8)
+
+
+def test_spm_detrend_order_zero_matches_general_path():
+    """The `if not p` shortcut must agree with the polynomial machinery."""
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((15, 4))
+    shortcut = spm.spm_detrend(x)
+    assert np.allclose(shortcut.sum(axis=0), 0.0, atol=1e-10)

--- a/rsHRF/unit_tests/test_spm.py
+++ b/rsHRF/unit_tests/test_spm.py
@@ -4,6 +4,7 @@ import os
 import math
 import numpy as np
 import nibabel as nib
+from scipy import signal
 from scipy.special import gammaln
 from ..spm_dep import spm
 
@@ -104,27 +105,38 @@ def test_spm_write_vol():
             os.remove(fname + file_type)
 
 
-def test_spm_detrend_removes_polynomial_trend():
+def test_spm_detrend_matches_scipy_for_linear_order():
+    """Independent reference: scipy removes a least-squares line for p = 1."""
+    rng = np.random.default_rng(3)
+    x = rng.standard_normal((30, 4)) + np.linspace(0, 5, 30)[:, None]
+    assert np.allclose(spm.spm_detrend(x, 1), signal.detrend(x, axis=0, type="linear"))
+
+
+def test_spm_detrend_removes_trend_and_keeps_the_rest():
     """p > 0 was unreachable: d.flatten(1) raised TypeError on modern NumPy."""
-    m = 20
+    m = 24
     t = np.arange(1, m + 1)
     for p in (1, 2, 3):
-        # columns that are exactly degree-p polynomials in t
-        x = np.column_stack(
-            [
-                np.polyval(np.polyfit(t, 2.0 + 0.5 * t + 0.01 * t**2, p), t),
-                np.polyval(np.polyfit(t, -1.0 + 0.2 * t - 0.001 * t**3, p), t),
-            ]
+        trend = np.polyval(
+            np.polyfit(t, 3.0 - 0.4 * t + 0.02 * t**2 - 0.0005 * t**3, p), t
         )
+        osc = np.sin(2 * np.pi * t / 6.0)
+        x = np.column_stack([trend + osc, trend - osc])
+
         y = spm.spm_detrend(x, p)
         assert y.shape == x.shape
-        # an exact polynomial of degree p must be removed entirely
-        assert np.allclose(y, 0.0, atol=1e-8)
+
+        # the polynomial trend is gone
+        G = np.column_stack([t**i for i in range(p + 1)]).astype(float)
+        assert np.allclose(np.linalg.pinv(G) @ y, 0.0, atol=1e-8)
+
+        # but the oscillation survives: an implementation that returns zeros fails here
+        assert np.abs(y).max() > 0.5
 
 
-def test_spm_detrend_order_zero_matches_general_path():
-    """The `if not p` shortcut must agree with the polynomial machinery."""
+def test_spm_detrend_order_zero_equals_mean_projection():
+    """The `if not p` shortcut must equal projecting out a constant column."""
     rng = np.random.default_rng(0)
     x = rng.standard_normal((15, 4))
-    shortcut = spm.spm_detrend(x)
-    assert np.allclose(shortcut.sum(axis=0), 0.0, atol=1e-10)
+    G = np.ones((15, 1))
+    assert np.allclose(spm.spm_detrend(x, 0), x - G @ np.linalg.pinv(G) @ x)


### PR DESCRIPTION
`spm_detrend(x, p)` raised `TypeError: order must be str, not int` for any `p > 0`.

`d` is `np.arange(1, m+1) ** i`, already 1-D. The `.flatten(1)` is a mistranslation of the
MATLAB idiom `d(:)` — the same pattern appears in the MATLAB toolbox's
`rsHRF_denoise_job.m`. Flattening a 1-D array is a no-op in any order, so the call is
removed rather than repaired.

Only `p = 0` was reachable, which is why this survived. The existing test was also unable
to catch it: replacing `spm_detrend` with a function that ignores its input and returns
`np.zeros_like(x)` made it pass, because it only asserted that the trend was gone, never
that anything survived.

Three tests replace it. `p = 1` is checked against `scipy.signal.detrend` as an
independent reference. `p = 1, 2, 3` must remove the polynomial trend while leaving a
superimposed oscillation intact. The `p = 0` shortcut is pinned to the projection it is
meant to equal. All three fail against the zeros-returning implementation.

`spm_detrend` is currently called by nothing but its own test. It is a port of SPM's
`spm_detrend`, not of anything in the rsHRF MATLAB toolbox — MATLAB implements its
`Polynomial Detrending` option inline as nuisance regressors, normalised by `Nscans^i`.
This Python version does not normalise, so the monomial basis is poorly conditioned for
large `p`; hence the `1e-8` tolerance rather than machine epsilon.