### PR TITLE
Fix: the lstsq fallbacks in smooth_fir never worked

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
   `"URI": null` when `RSHRF_SINGULARITY_URL` was set. Both branches now read the variable they gate on.
 * `[Fixed]` `write_derivative_description` no longer prints the version string to stdout.
 * `[Fixed]` `spm_detrend` raised `TypeError` for polynomial order > 0.
+* `[Fixed]` the `linalg.solve` fallbacks in `sFIR/smooth_fir.py` assigned `lstsq`'s 4-tuple
+  rather than its solution, so they raised `ValueError` instead of falling back.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/sFIR/smooth_fir.py
+++ b/rsHRF/sFIR/smooth_fir.py
@@ -32,10 +32,10 @@ def wgr_regress(y, X):
     if R.shape[0] == R.shape[1]:
         try:
             b[perm] = linalg.solve(R, np.matmul(Q.T, y))
-        except:
-            b[perm] = linalg.lstsq(R, np.matmul(Q.T, y))
+        except linalg.LinAlgError:
+            b[perm] = linalg.lstsq(R, np.matmul(Q.T, y))[0]
     else:
-        b[perm] = linalg.lstsq(R, np.matmul(Q.T, y))
+        b[perm] = linalg.lstsq(R, np.matmul(Q.T, y))[0]
     return b
 
 
@@ -66,8 +66,8 @@ def wgr_glsco(X, Y, sMRI=[], AR_lag=0, max_iter=20):
         sMRI = np.array(sMRI)
         try:
             Beta = linalg.solve(np.matmul(X.T, X) + sMRI, np.matmul(X.T, Y))
-        except:
-            Beta = linalg.lstsq(np.matmul(X.T, X) + sMRI, np.matmul(X.T, Y))
+        except linalg.LinAlgError:
+            Beta = linalg.lstsq(np.matmul(X.T, X) + sMRI, np.matmul(X.T, Y))[0]
     resid = Y - np.matmul(X, Beta)
     if AR_lag == 0:
         res_sum = np.cov(resid)
@@ -92,10 +92,10 @@ def wgr_glsco(X, Y, sMRI=[], AR_lag=0, max_iter=20):
                 Beta = linalg.solve(
                     np.matmul(X_main.T, X_main) + sMRI, np.matmul(X_main.T, Y_main)
                 )
-            except:
+            except linalg.LinAlgError:
                 Beta = linalg.lstsq(
                     np.matmul(X_main.T, X_main) + sMRI, np.matmul(X_main.T, Y_main)
-                )
+                )[0]
         resid = Y[AR_lag:nobs] - X[AR_lag:nobs, :].dot(Beta)
         if max(np.absolute(Beta - Beta_temp)) < max_tol:
             break
@@ -135,9 +135,9 @@ def Fit_sFIR2(output, length, TR, input, T, flag_sfir, AR_lag):
         sMRI[0:NN, 0:NN] = sMRI0
         if AR_lag == 0:
             try:
-                hrf = linalg.solve((np.matmul(X.T, X) + sMRI), np.matmul(X.T, output))
-            except:
-                hrf = linalg.lstsq((np.matmul(X.T, X) + sMRI), np.matmul(X.T, output))
+                hrf = linalg.solve(np.matmul(X.T, X) + sMRI, np.matmul(X.T, output))
+            except linalg.LinAlgError:
+                hrf = linalg.lstsq(np.matmul(X.T, X) + sMRI, np.matmul(X.T, output))[0]
             resid = output - np.matmul(X, hrf)
             res_sum = np.cov(resid)
         else:

--- a/rsHRF/unit_tests/test_smooth_fir.py
+++ b/rsHRF/unit_tests/test_smooth_fir.py
@@ -419,3 +419,21 @@ def test_wgr_FIR_estimation_HRF():
         ]
     )
     assert np.allclose(out2_exp, out2)
+
+
+def test_wgr_glsco_falls_back_when_solve_hits_a_singular_matrix():
+    """The except branch assigned lstsq's 4-tuple, so the fallback raised ValueError."""
+    # X.T @ X = [[14, 28], [28, 56]] -- determinant is exactly 0 in float arithmetic,
+    # so linalg.solve raises LinAlgError deterministically rather than merely warning.
+    X = np.array([[1.0, 2.0], [2.0, 4.0], [3.0, 6.0]])
+    Y = np.array([1.0, 0.0, -1.0])
+    sMRI = np.zeros((2, 2))
+
+    res_sum, Beta = smooth_fir.wgr_glsco(X, Y, sMRI=sMRI, AR_lag=0)
+
+    assert isinstance(Beta, np.ndarray)
+    assert Beta.shape == (2,)
+    assert np.all(np.isfinite(Beta))
+    # the defining property of a least-squares solution: residual orthogonal to X.
+    # zeros, X.T @ Y and ones all fail this, so it cannot be satisfied by accident.
+    assert np.allclose(X.T @ (Y - X @ Beta), 0.0, atol=1e-8)


### PR DESCRIPTION
* scipy.linalg.lstsq returns (x, residues, rank, s); the code assigned the whole tuple, so the except branch raised ValueError one line later instead of falling back
* narrow the bare except to LinAlgError, which is what solve actually raises
* drop two redundant parens so the try/except arms format identically