### PR TITLE
Fix: reject malformed temporal-mask files instead of corrupting them

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * `[Fixed]` `spm_detrend` raised `TypeError` for polynomial order > 0.
 * `[Fixed]` the `linalg.solve` fallbacks in `sFIR/smooth_fir.py` assigned `lstsq`'s 4-tuple
   rather than its solution, so they raised `ValueError` instead of falling back.
+* `[Fixed]` the `--temporal-mask` parser now rejects files containing anything other than 0s, 1s and separators, instead of silently dropping the bad characters and building a wrong-length mask.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/CLI.py
+++ b/rsHRF/CLI.py
@@ -400,15 +400,23 @@ def run_rsHRF():
 
         if args.temporal_mask is not None:
             try:
-                f = open(args.temporal_mask, "r")
-                for line in f:
-                    for each in line:
-                        if each in ["0", "1"]:
-                            temporal_mask.append(int(each))
-            except:
+                with open(args.temporal_mask, "r") as f:
+                    content = f.read()
+            except (OSError, UnicodeDecodeError):
                 parser.error(
-                    "Unable to read temporal mask file. Please make sure the file is a text file, consisting of a sequence of 0s and 1s of the same length as the signal"
+                    "Unable to read temporal mask file. Please make sure it is a text "
+                    "file consisting of a sequence of 0s and 1s of the same length as "
+                    "the signal."
                 )
+            for each in content:
+                if each in ["0", "1"]:
+                    temporal_mask.append(int(each))
+                elif not (each.isspace() or each in [",", ";"]):
+                    parser.error(
+                        "Invalid character %r in temporal mask file; expected only 0s "
+                        "and 1s, optionally separated by whitespace, commas or "
+                        "semicolons." % each
+                    )
 
         if input_type != "BIDS":
             if para["TR"] <= 0:

--- a/rsHRF/unit_tests/test_cli.py
+++ b/rsHRF/unit_tests/test_cli.py
@@ -795,3 +795,56 @@ def test_BIDS_filters(monkeypatch, tmp_path):
         )
         CLI.run_rsHRF()
         mock_call.assert_called_once()
+
+
+def test_temporal_mask_rejects_non_binary_tokens(monkeypatch, tmp_path):
+    """A text file with a stray non-0/1 token was silently absorbed into a wrong mask."""
+    d = tmp_path / "sub"
+    d.mkdir()
+    (d / "hello.txt").write_text("mock", encoding="utf-8")
+    bad = d / "mask.txt"
+    bad.write_text("0 1 2 1", encoding="utf-8")  # the '2' used to vanish -> [0, 1, 1]
+    with mock.patch("rsHRF.fourD_rsHRF.demo_rsHRF"):
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "rsHRF",
+                str(d / "hello.txt"),
+                str(d),
+                "--no-bids",
+                "--TR",
+                "2",
+                "--temporal-mask",
+                str(bad),
+            ],
+        )
+        with pytest.raises(SystemExit):
+            CLI.run_rsHRF()
+
+
+def test_temporal_mask_accepts_valid_formats(monkeypatch, tmp_path):
+    """A concatenated row and separator-delimited files must both still parse."""
+    d = tmp_path / "sub"
+    d.mkdir()
+    (d / "hello.txt").write_text("mock", encoding="utf-8")
+    for content in ("01011100", "0 1 0 1 1 1 0 0", "0,1,0,1"):
+        m = d / "mask.txt"
+        m.write_text(content, encoding="utf-8")
+        with mock.patch("rsHRF.fourD_rsHRF.demo_rsHRF") as mock_call:
+            monkeypatch.setattr(
+                sys,
+                "argv",
+                [
+                    "rsHRF",
+                    str(d / "hello.txt"),
+                    str(d),
+                    "--no-bids",
+                    "--TR",
+                    "2",
+                    "--temporal-mask",
+                    str(m),
+                ],
+            )
+            CLI.run_rsHRF()
+            mock_call.assert_called_once()


### PR DESCRIPTION
The `--temporal-mask` parser walked the file character by character and kept anything
that was `0` or `1`, discarding everything else. Separators (spaces, commas, newlines)
were harmless, but any *other* character was silently swallowed: `0 1 2 1` became
`[0, 1, 1]`, a float mask `1.0 0.0` became `[1, 0, 0, 0]`, and a header line contributed
nothing. The result was a wrong-length or wrong-content mask, which the downstream
`len(mask) != nobs` check catches only when the length happens to differ.

Now each character must be `0`, `1`, or a separator (whitespace / `,` / `;`); anything
else raises `parser.error`. The two documented formats — a single concatenated row like
`01011100` and separator-delimited values — still parse unchanged, pinned by the added
`test_temporal_mask_accepts_valid_formats`.

Also switched to `with open(...)` (the handle was never closed) and narrowed the bare
`except:` to `OSError`/`UnicodeDecodeError` — the latter is what the existing
"non-text file" test relies on.

The consumer of this mask in `hrf_estimation.py` has a separate, unrelated bug (it mutates
the caller's list and can drop frame 0); that is not touched here.