### PR TITLE
Chore: remove dead dependencies and fix the repository URL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 * `[Fixed]` the `linalg.solve` fallbacks in `sFIR/smooth_fir.py` assigned `lstsq`'s 4-tuple
   rather than its solution, so they raised `ValueError` instead of falling back.
 * `[Fixed]` the `--temporal-mask` parser now rejects files containing anything other than 0s, 1s and separators, instead of silently dropping the bad characters and building a wrong-length mask.
+* `[Changed]` removed the unused `mpld3` import and the unused `duecredit` dependency.
+* `[Fixed]` the repository URL in `__about__.py` (`BIDSapps` -> `BIDS-Apps`).
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ matplotlib
 pybids==0.11.1
 pandas
 patsy
-mpld3
 joblib
 PyWavelets

--- a/rsHRF/__about__.py
+++ b/rsHRF/__about__.py
@@ -6,6 +6,6 @@ with open(op.join(op.dirname(op.realpath(__file__)), "VERSION"), "r") as fh:
     __version__ = fh.read().strip("\n")
 
 __packagename__ = "rsHRF"
-__url__ = "https://github.com/BIDSapps/rsHRF"
+__url__ = "https://github.com/BIDS-Apps/rsHRF"
 
 DOWNLOAD_URL = "https://github.com/BIDS-Apps/{name}/".format(name=__packagename__)

--- a/rsHRF/rsHRF_GUI/gui_windows/plotterWindow.py
+++ b/rsHRF/rsHRF_GUI/gui_windows/plotterWindow.py
@@ -1,4 +1,3 @@
-import mpld3
 import matplotlib
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,6 @@ setup(
         "pybids==0.11.1",
         "pandas",
         "patsy",
-        "mpld3",
-        "duecredit",
         "joblib",
         "PyWavelets",
     ],


### PR DESCRIPTION
Three dead things, all checked before removing.

`mpld3` — imported at the top of `plotterWindow.py` and never used anywhere. The plotting
is all `FigureCanvasTkAgg`. Dropped the import and the dependency.

`duecredit` — in `install_requires`, but nothing in the codebase imports it. Every install
has been downloading it for no reason.

`__about__.py:9` — the URL said `BIDSapps`. Line 11 right below it, and `setup.py`, already
say `BIDS-Apps`. Just a typo nobody caught.

Nothing here was ever executed, so nothing changes.

One thing: `test_gnii` fails on this branch but it also fails on a clean `develop`, I
checked with `git stash`. It's the `localK` change from #37: the test still expects `None`
but CLI now derives `1` from TR. Not from this PR, left it alone.