### PR TITLE
Fix: use os.path.basename instead of hardcoded "/" for path parsing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * `[Fixed]` the `--temporal-mask` parser now rejects files containing anything other than 0s, 1s and separators, instead of silently dropping the bad characters and building a wrong-length mask.
 * `[Changed]` removed the unused `mpld3` import and the unused `duecredit` dependency.
 * `[Fixed]` the repository URL in `__about__.py` (`BIDSapps` -> `BIDS-Apps`).
+* `[Fixed]` file paths are now parsed with `os.path.basename` instead of `split("/")`, so filename and subject-ID extraction works on Windows.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/CLI.py
+++ b/rsHRF/CLI.py
@@ -628,8 +628,8 @@ def run_rsHRF():
 
                 prefix_match_count = 0
                 for i in range(len(all_inputs)):
-                    input_prefix = all_inputs[i].split("/")[-1].split("_desc")[0]
-                    mask_prefix = all_masks[i].split("/")[-1].split("_desc")[0]
+                    input_prefix = op.basename(all_inputs[i]).split("_desc")[0]
+                    mask_prefix = op.basename(all_masks[i]).split("_desc")[0]
                     if input_prefix == mask_prefix:
                         prefix_match_count += 1
                     else:

--- a/rsHRF/fourD_rsHRF.py
+++ b/rsHRF/fourD_rsHRF.py
@@ -40,17 +40,17 @@ def demo_rsHRF(
     # for four-dimensional input
     if mode != "time-series":
         if mode == "bids" or mode == "bids w/ atlas":
-            name = input_file.split("/")[-1].split(".")[0]
+            name = os.path.basename(input_file).split(".")[0]
             v1 = spm_dep.spm.spm_vol(input_file)
         else:
-            name = input_file.split("/")[-1].split(".")[0]
+            name = os.path.basename(input_file).split(".")[0]
             v1 = spm_dep.spm.spm_vol(input_file)
         if mask_file != None:
             if mode == "bids":
-                mask_name = mask_file.split("/")[-1].split(".")[0]
+                mask_name = os.path.basename(mask_file).split(".")[0]
                 v = spm_dep.spm.spm_vol(mask_file)
             else:
-                mask_name = mask_file.split("/")[-1].split(".")[0]
+                mask_name = os.path.basename(mask_file).split(".")[0]
                 v = spm_dep.spm.spm_vol(mask_file)
             if file_type == ".nii" or file_type == ".nii.gz":
                 brain = spm_dep.spm.spm_read_vols(v)
@@ -93,7 +93,7 @@ def demo_rsHRF(
         bold_sig = stats.zscore(data1[:, voxel_ind], ddof=1)
     # for time-series input
     else:
-        name = input_file.split("/")[-1].split(".")[0]
+        name = os.path.basename(input_file).split(".")[0]
         data1 = np.loadtxt(input_file, delimiter=",")
         if data1.ndim == 1:
             data1 = np.expand_dims(data1, axis=1)

--- a/rsHRF/rsHRF_GUI/core/core.py
+++ b/rsHRF/rsHRF_GUI/core/core.py
@@ -156,8 +156,8 @@ class Core:
                 all_prefix_match = False
                 prefix_match_count = 0
                 for i in range(len(all_inputs)):
-                    input_prefix = all_inputs[i].split("/")[-1].split("_desc")[0]
-                    mask_prefix = all_masks[i].split("/")[-1].split("_desc")[0]
+                    input_prefix = os.path.basename(all_inputs[i]).split("_desc")[0]
+                    mask_prefix = os.path.basename(all_masks[i]).split("_desc")[0]
 
                     if input_prefix == mask_prefix:
                         prefix_match_count += 1
@@ -204,7 +204,7 @@ class Core:
             mask_file = mask_file
         # getting the subject index
         try:
-            subject_index = input_file.split("/")[-1].split("_")[0][4:]
+            subject_index = os.path.basename(input_file).split("_")[0][4:]
         except:
             return Status(False, error="Input file should begin with 'sub-'")
         # obtaining the header for the mask

--- a/rsHRF/rsHRF_GUI/gui_windows/inputWindow.py
+++ b/rsHRF/rsHRF_GUI/gui_windows/inputWindow.py
@@ -87,7 +87,7 @@ class InputWindow:
                     self.file_type = ()
 
             try:
-                inputFileLabel.configure(text=self.input_file.split("/")[-1])
+                inputFileLabel.configure(text=os.path.basename(self.input_file))
             except Exception:
                 inputFileLabel.configure(text="")
 
@@ -107,7 +107,7 @@ class InputWindow:
         def getMaskFile():
             self.mask_file = ask_image_filename("Mask File Path")
             try:
-                maskFileLabel.configure(text=self.mask_file.split("/")[-1])
+                maskFileLabel.configure(text=os.path.basename(self.mask_file))
             except Exception:
                 maskFileLabel.configure(text="")
 
@@ -115,7 +115,8 @@ class InputWindow:
             self.output_dir = filedialog.askdirectory(initialdir=os.getcwd())
             try:
                 outputPathLabel.configure(
-                    text="Output path: " + self.output_dir.split("/")[-1]
+                    text="Output path: "
+                    + os.path.basename(self.output_dir.rstrip("/\\"))
                 )
             except Exception:
                 outputPathLabel.configure(text="")


### PR DESCRIPTION
`split("/")[-1]` returns the entire path on Windows, so every place that
pulled a filename or subject ID out of a path was broken there. Replaced
with `os.path.basename` across 13 sites in fourD_rsHRF.py, CLI.py,
core.py and inputWindow.py.

One is different: output_dir is a directory. basename returns "" on a
trailing separator, so it's stripped first — both "/" and "\", so the
label holds on Windows.


