### PR TITLE
Fix: check events of the plotted voxel, not the whole event_bold array

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * `[Changed]` removed the unused `mpld3` import and the unused `duecredit` dependency.
 * `[Fixed]` the repository URL in `__about__.py` (`BIDSapps` -> `BIDS-Apps`).
 * `[Fixed]` file paths are now parsed with `os.path.basename` instead of `split("/")`, so filename and subject-ID extraction works on Windows.
+* `[Fixed]` the "No Events Detected!" check now looks at the events of the voxel being plotted (`event_bold[pos]`) instead of the size of the whole `event_bold` array, which was almost always non-zero. Also guards against `pos` overflowing when no voxel has an HRF.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/fourD_rsHRF.py
+++ b/rsHRF/fourD_rsHRF.py
@@ -247,7 +247,7 @@ def demo_rsHRF(
         pos += 1
 
     event_plot = lil_matrix((1, nobs))
-    if event_bold.size:
+    if pos < hrfa_TR.shape[1] and event_bold[pos].size:
         event_plot[:, event_bold[pos]] = 1
     else:
         print("No Events Detected!")


### PR DESCRIPTION
The "No Events Detected!" guard checked `event_bold.size` but event_bold is an
object array of per-voxel event lists, so `.size` counts voxels (almost always
non-zero) rather than events. The message essentially never fired, even when the
voxel being plotted had no events.

It now checks `event_bold[pos].size` — the events of the voxel actually being
plotted (the first one with a non-zero HRF).

I also added `pos < hrfa_TR.shape[1]` to the same condition. If no voxel has a
non-zero HRF, the while loop above leaves `pos` one past the end of the array, so
`event_bold[pos]` would raise IndexError. The `and` short-circuits, so when pos
overflowed it now falls through to "No Events Detected!" instead of crashing.

Only touches the plotting branch — the deconvolved output (.mat / NIfTI) is written
earlier, before this point, so results are unaffected.

CI note: test_gnii fails here, but it also fails on a clean develop (localK from #37
— the test expects None, CLI derives 1). Unrelated to this PR.