### PR TITLE
Fix: catch Exception instead of bare except in the BIDS loop

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * `[Fixed]` the repository URL in `__about__.py` (`BIDSapps` -> `BIDS-Apps`).
 * `[Fixed]` file paths are now parsed with `os.path.basename` instead of `split("/")`, so filename and subject-ID extraction works on Windows.
 * `[Fixed]` the "No Events Detected!" check now looks at the events of the voxel being plotted (`event_bold[pos]`) instead of the size of the whole `event_bold` array, which was almost always non-zero. Also guards against `pos` overflowing when no voxel has an HRF.
+* `[Fixed]` the BIDS processing loop now catches `Exception` instead of a bare `except:`, so `KeyboardInterrupt` (Ctrl+C) and `SystemExit` are no longer swallowed while iterating over input-mask pairs.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/CLI.py
+++ b/rsHRF/CLI.py
@@ -695,7 +695,7 @@ def run_rsHRF():
                     num_errors -= 1
                 except ValueError as err:
                     print(err.args[0])
-                except:
+                except Exception:
                     print("Unexpected error:", sys.exc_info()[0])
             success = len(all_inputs) - num_errors
             if success == 0:


### PR DESCRIPTION
A bare `except:` in the per-file BIDS processing loop caught BaseException, so
KeyboardInterrupt (Ctrl+C) and SystemExit were swallowed. The run couldn't be
interrupted. Narrowed to `except Exception:`, which still keeps the loop going on
real per-file errors but lets Ctrl+C and exit through.

