### PR TITLE
Fix: derive localK in test_gnii to match CLI behaviour

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * `[Fixed]` the "No Events Detected!" check now looks at the events of the voxel being plotted (`event_bold[pos]`) instead of the size of the whole `event_bold` array, which was almost always non-zero. Also guards against `pos` overflowing when no voxel has an HRF.
 * `[Fixed]` the BIDS processing loop now catches `Exception` instead of a bare `except:`, so `KeyboardInterrupt` (Ctrl+C) and `SystemExit` are no longer swallowed while iterating over input-mask pairs.
 * `[Fixed]` the GIfTI mask/input dimension check compared the input to itself (`v` vs `v`) so it never detected a mismatch; it now compares the input against the mask (`v1` vs `v`), like the NIfTI branch.
+* `[Fixed]` `test_gnii` now derives `localK` from `TR` the same way `CLI.py` does, so the test matches the runtime behaviour introduced in #37 instead of comparing against the raw `None` default.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/unit_tests/test_cli.py
+++ b/rsHRF/unit_tests/test_cli.py
@@ -262,6 +262,8 @@ def test_gnii(monkeypatch, tmp_path):
                     np.trunc(para["max_onset_search"] / para["dt"]) + 1,
                     dtype="int",
                 )
+                if para["localK"] is None:
+                    para["localK"] = 1 if para["TR"] <= 2 else 2
                 mock_call.assert_called_once()
 
                 call_args = mock_call.call_args


### PR DESCRIPTION
Since #37, default_parameters localK is None and CLI derives it from TR (TR<=2 -> 1, else 2). The test still read the raw None default and compared it to the derived 1, so test_gnii failed on every branch. Added the same derivation to the test's para setup so it matches what CLI actually passes to demo_rsHRF.