### PR TITLE
Replace deprecated numpy.matlib.repmat with numpy.tile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * `[Fixed]` the BIDS processing loop now catches `Exception` instead of a bare `except:`, so `KeyboardInterrupt` (Ctrl+C) and `SystemExit` are no longer swallowed while iterating over input-mask pairs.
 * `[Fixed]` the GIfTI mask/input dimension check compared the input to itself (`v` vs `v`) so it never detected a mismatch; it now compares the input against the mask (`v1` vs `v`), like the NIfTI branch.
 * `[Fixed]` `test_gnii` now derives `localK` from `TR` the same way `CLI.py` does, so the test matches the runtime behaviour introduced in #37 instead of comparing against the raw `None` default.
+* `[Changed]` Replaced deprecated `numpy.matlib.repmat` with `numpy.tile` in `rest_filter.py`; `numpy.matlib` is deprecated and the two produce identical output for the scalar-mean broadcast used here.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/processing/rest_filter.py
+++ b/rsHRF/processing/rest_filter.py
@@ -1,5 +1,4 @@
 import numpy as np
-import numpy.matlib
 import warnings
 
 warnings.filterwarnings("ignore")
@@ -14,7 +13,7 @@ def rest_IdealFilter(x, TR, Bands, m=5000):
         else:
             ind_X = [j for j in range((i - 1) * m, nvar)]
         x1 = x[:, ind_X]
-        x1 = conn_filter(TR, Bands, x1) + np.matlib.repmat(np.mean(x1), x1.shape[0], 1)
+        x1 = conn_filter(TR, Bands, x1) + np.tile(np.mean(x1), (x1.shape[0], 1))
         x[:, ind_X] = x1
     return x
 


### PR DESCRIPTION
numpy.matlib is deprecated. In rest_IdealFilter the call repmat(mean(x1), N, 1) tiles a scalar into an (N,1) column; np.tile(mean(x1), (N,1)) produces identical output (verified array-equal across shapes), so this is a API-modernization change with no effect on results.