### PR TITLE
Fix: FIR/sFIR searched delays drifting outside the requested window

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * `[Fixed]` the GIfTI mask/input dimension check compared the input to itself (`v` vs `v`) so it never detected a mismatch; it now compares the input against the mask (`v1` vs `v`), like the NIfTI branch.
 * `[Fixed]` `test_gnii` now derives `localK` from `TR` the same way `CLI.py` does, so the test matches the runtime behaviour introduced in #37 instead of comparing against the raw `None` default.
 * `[Changed]` Replaced deprecated `numpy.matlib.repmat` with `numpy.tile` in `rest_filter.py`; `numpy.matlib` is deprecated and the two produce identical output for the scalar-mean broadcast used here.
+* `[Fixed]` FIR/sFIR estimation now recomputes the lag range after `T` is reset to 1, and the search loop iterates over the lag values instead of the loop counter, so it searches delays within the requested `[min_onset_search, max_onset_search]` window instead of drifting outside it.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/fourD_rsHRF.py
+++ b/rsHRF/fourD_rsHRF.py
@@ -126,6 +126,12 @@ def demo_rsHRF(
     if para["estimation"] == "sFIR" or para["estimation"] == "FIR":
         # Estimate HRF for FIR and sFIR
         para["T"] = 1
+        para["dt"] = para["TR"] / para["T"]
+        para["lag"] = np.arange(
+            np.trunc(para["min_onset_search"] / para["dt"]),
+            np.trunc(para["max_onset_search"] / para["dt"]) + 1,
+            dtype=int,
+        )
         beta_hrf, event_bold = utils.hrf_estimation.compute_hrf(
             bold_sig, para, temporal_mask, p_jobs
         )

--- a/rsHRF/sFIR/smooth_fir.py
+++ b/rsHRF/sFIR/smooth_fir.py
@@ -164,7 +164,7 @@ def wgr_FIR_estimation_HRF(u, dat, para, N):
     hrf = np.zeros((len_bin + 1, nlag))
     Cov_E = np.zeros((1, nlag))
     kk = 0
-    for i_lag in range(1, nlag + 1):
+    for i_lag in lag:
         RR = u - i_lag
         RR = RR[RR >= 0]
         if RR.size != 0:

--- a/rsHRF/unit_tests/test_smooth_fir.py
+++ b/rsHRF/unit_tests/test_smooth_fir.py
@@ -437,3 +437,53 @@ def test_wgr_glsco_falls_back_when_solve_hits_a_singular_matrix():
     # the defining property of a least-squares solution: residual orthogonal to X.
     # zeros, X.T @ Y and ones all fail this, so it cannot be satisfied by accident.
     assert np.allclose(X.T @ (Y - X @ Beta), 0.0, atol=1e-8)
+
+
+class _DelayRecorder:
+    """Wraps the event vector u and records which shifts the FIR loop
+    subtracts, so a test can observe exactly which delays were searched
+    without modifying the function under test."""
+
+    def __init__(self, u):
+        self.u = np.asarray(u)
+        self.searched = []
+
+    def __sub__(self, shift):
+        self.searched.append(int(shift))
+        return self.u - shift
+
+
+def test_fir_searches_within_requested_window():
+    """FIR/sFIR must search only delays inside the user's
+    [min_onset_search, max_onset_search] window. Before the lag-recompute
+    fix the loop shifted by the counter 1..nlag, so it drifted outside the
+    window (e.g. searching 1s and 2s when 6-8s was requested). Several
+    (TR, window) cases are checked because the drift is masked for some
+    combinations and only visible for others."""
+    cases = [(2.0, 4, 8), (1.0, 6, 8), (1.5, 4, 8), (3.0, 6, 10)]
+
+    for TR, min_onset, max_onset in cases:
+        dt = TR / 1  # FIR resets T to 1, so dt = TR
+        lag = np.arange(
+            np.trunc(min_onset / dt),
+            np.trunc(max_onset / dt) + 1,
+            dtype=int,
+        )
+        # event indices large enough that u - i_lag stays positive,
+        # so the fitting path is actually exercised
+        u = _DelayRecorder(np.array([20, 55, 90, 120]))
+        para = {
+            "estimation": "FIR",
+            "TR": TR,
+            "AR_lag": 1,
+            "len": 24,
+            "lag": lag,
+        }
+        smooth_fir.wgr_FIR_estimation_HRF(u, np.linspace(-1, 1, 152), para, 152)
+
+        for shift in u.searched:
+            d = shift * TR
+            assert min_onset - dt <= d <= max_onset, (
+                f"TR={TR} [{min_onset}, {max_onset}]: "
+                f"FIR searched {d}s, outside the requested window"
+            )


### PR DESCRIPTION
Two bugs compounded. CLI builds the lag range with the default T=3, then fourD_rsHRF resets T to 1 for FIR/sFIR without recomputing lag, so the stored indices no longer mean what they did. And the search loop in smooth_fir iterated with the counter 1..nlag instead of lag's values. Together the estimator searched delays like 2-14s when the user asked for 4-8s. Fix recomputes lag after T=1 (same formula as CLI) and iterates over lag values. Adds a regression test that observes the actually-searched delays via a recorder object and checks they stay within the requested window across several TR/window combinations.