### PR TITLE
Fix: height read one sample too early on a plateau

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * `[Fixed]` `test_gnii` now derives `localK` from `TR` the same way `CLI.py` does, so the test matches the runtime behaviour introduced in #37 instead of comparing against the raw `None` default.
 * `[Changed]` Replaced deprecated `numpy.matlib.repmat` with `numpy.tile` in `rest_filter.py`; `numpy.matlib` is deprecated and the two produce identical output for the scalar-mean broadcast used here.
 * `[Fixed]` FIR/sFIR estimation now recomputes the lag range after `T` is reset to 1, and the search loop iterates over the lag values instead of the loop counter, so it searches delays within the requested `[min_onset_search, max_onset_search]` window instead of drifting outside it.
+* `[Fixed]` `wgr_get_parameters` read the response height one sample too early when the peak sits at the end of a plateau: the plateau walk-back assigned `hdrf[cnt - 1]` where MATLAB's `rsHRF_get_HRF_parameters.m` uses `hdrf(cnt)`, i.e. `hdrf[cnt]` zero-based. Only the height map was affected; time-to-peak and FWHM were already correct.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/parameters.py
+++ b/rsHRF/parameters.py
@@ -8,7 +8,7 @@ def wgr_get_parameters(hdrf, dt):
     """
     Find Model Parameters
     h - Height
-    p - Time to peak (in units of dt where dt = TR/para.T)
+    p - Time to peak (in units of dt where dt = para["TR"] / para["T"])
     w - Width at half-peak
     """
     param = np.zeros((3, 1))
@@ -32,7 +32,7 @@ def wgr_get_parameters(hdrf, dt):
         g = hdrf[1:] - hdrf[0:-1]
 
         while cnt > 0 and np.abs(g[cnt]) < 0.001:
-            h = hdrf[cnt - 1]
+            h = hdrf[cnt]
             p = cnt
             cnt = cnt - 1
 

--- a/rsHRF/unit_tests/test_parameters.py
+++ b/rsHRF/unit_tests/test_parameters.py
@@ -33,3 +33,16 @@ def test_wgr_get_parameters():
         ),
         np.asarray([0.92579636, 0.3, 0.1]),
     )
+
+
+def test_height_uses_plateau_start():
+    """If the peak is at the end of a plateau, function will walk backwards and take the height value from the beginning of the plateau."""
+    dt = 2.0
+    vector = np.asarray(
+        [0.0, 0.20, 0.60, 0.9000, 0.9003, 0.9005, 0.9010, 0.5, 0.2, -0.1, 0.0, 0.0]
+    )
+    result = parameters.wgr_get_parameters(vector, dt)
+    expected = np.asarray([0.9, 8.0, 12.0])
+    assert np.allclose(
+        result, expected
+    ), f"Height should come from the plateau start expected: {expected} got:{result}"


### PR DESCRIPTION
`wgr_get_parameters` walks back from the peak while the derivative stays below
0.001, to find where a plateau starts. It assigned `hdrf[cnt - 1]`, one sample
too early.

MATLAB's `rsHRF_get_HRF_parameters.m` (line 33) uses `h = hdrf(cnt)`. Since
`cnt` here is already the zero-based counterpart of MATLAB's `cnt`, the
equivalent is `hdrf[cnt]`. The `g[cnt]` condition and the `p = cnt` assignment
in the same loop were already translated correctly; only this line applied the
index shift twice.

Only the height map is affected, time-to-peak and FWHM were correct.

The new test uses a vector whose peak sits at the end of a plateau, which is
what forces the loop to run. None of the existing assertions reach it: they
pass zeros, ones, or a vector whose derivative never drops below the threshold.
Reverting the fix turns the new test red, returning `0.6` instead of `0.9`.

Also fixes the docstring, which described `dt` in MATLAB notation
(`TR/para.T`); both call sites pass `para["TR"] / para["T"]`.