### PR TITLE
Fix: GUI FIR/sFIR searched delays outside the requested window

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * `[Changed]` Replaced deprecated `numpy.matlib.repmat` with `numpy.tile` in `rest_filter.py`; `numpy.matlib` is deprecated and the two produce identical output for the scalar-mean broadcast used here.
 * `[Fixed]` FIR/sFIR estimation now recomputes the lag range after `T` is reset to 1, and the search loop iterates over the lag values instead of the loop counter, so it searches delays within the requested `[min_onset_search, max_onset_search]` window instead of drifting outside it.
 * `[Fixed]` `wgr_get_parameters` read the response height one sample too early when the peak sits at the end of a plateau: the plateau walk-back assigned `hdrf[cnt - 1]` where MATLAB's `rsHRF_get_HRF_parameters.m` uses `hdrf(cnt)`, i.e. `hdrf[cnt]` zero-based. Only the height map was affected; time-to-peak and FWHM were already correct.
+* `[Fixed]` The GUI's FIR/sFIR path never reset `T` to 1 or recomputed the lag range, because `Core.retrieveHRF` calls `compute_hrf` directly instead of going through `fourD_rsHRF`. With the default `T = 3` it searched delays three times outside the requested window — 12-24s for the default `[4, 8]` request. Both paths now call `apply_fir_microtime_grid`, so the fix from #45 can no longer apply to one caller and not the other.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/fourD_rsHRF.py
+++ b/rsHRF/fourD_rsHRF.py
@@ -125,13 +125,7 @@ def demo_rsHRF(
     # Estimate HRF for the fourier / hanning / gamma / cannon basis functions
     if para["estimation"] == "sFIR" or para["estimation"] == "FIR":
         # Estimate HRF for FIR and sFIR
-        para["T"] = 1
-        para["dt"] = para["TR"] / para["T"]
-        para["lag"] = np.arange(
-            np.trunc(para["min_onset_search"] / para["dt"]),
-            np.trunc(para["max_onset_search"] / para["dt"]) + 1,
-            dtype=int,
-        )
+        utils.hrf_estimation.apply_fir_microtime_grid(para)
         beta_hrf, event_bold = utils.hrf_estimation.compute_hrf(
             bold_sig, para, temporal_mask, p_jobs
         )

--- a/rsHRF/rsHRF_GUI/core/core.py
+++ b/rsHRF/rsHRF_GUI/core/core.py
@@ -324,6 +324,7 @@ class Core:
             )
             para = self.parameters.get_parameters()
             if para["estimation"] == "sFIR" or para["estimation"] == "FIR":
+                utils.hrf_estimation.apply_fir_microtime_grid(para)
                 # estimate HRF for FIR and sFIR
                 beta_hrf, event_bold = utils.hrf_estimation.compute_hrf(
                     bold_sig, para, [], -1

--- a/rsHRF/utils/hrf_estimation.py
+++ b/rsHRF/utils/hrf_estimation.py
@@ -13,6 +13,24 @@ import warnings
 
 warnings.filterwarnings("ignore")
 
+
+def apply_fir_microtime_grid(para):
+    """
+    sFIR/FIR cannot use a time grid finer than TR,
+    thus we fix micro-time resolution factor to (T=1), this function makes sure
+    lag is computed accurately depending on dt and T
+    dt= TR / T
+    lag is in units of dt
+    """
+    para["T"] = 1
+    para["dt"] = para["TR"] / para["T"]
+    para["lag"] = np.arange(
+        np.trunc(para["min_onset_search"] / para["dt"]),
+        np.trunc(para["max_onset_search"] / para["dt"]) + 1,
+        dtype=int,
+    )
+
+
 """
 HRF ESTIMATION
 """


### PR DESCRIPTION
`Core.retrieveHRF` calls `compute_hrf` directly and never goes through
`fourD_rsHRF`, so it missed the `T = 1` reset and the lag recomputation that
#45 added. With the default `T = 3` the GUI searched 12-24s when the user
asked for 4-8s, on every FIR/sFIR run.

Two commits: the first extracts the setup into a helper and points
`fourD_rsHRF` at it (no behaviour change); the second
points the GUI at the same helper. A helper rather than a copy, because the
copy is what caused this — #45 fixed one call site and the other kept a stale
grid.