### PR TITLE
FIX: use DatasetType instead of DataType in dataset_description.json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
 
-  - repo: https://github.com/psf/black
-    rev: 24.3.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.5.1
     hooks:
       - id: black

--- a/NEWS.md
+++ b/NEWS.md
@@ -104,9 +104,12 @@ intercept as part of the HRF.
   and warnings from dependencies. Voxels excluded for having a flat time course are now reported
   once per run, with a count and the likely cause, instead of warning per voxel.
 * `[Fixed]` The BIDS input check required `DataType` in `dataset_description.json`, but the
-  BIDS key is `DatasetType`, which is also what `utils/bids.py` writes — so rsHRF rejected
+  BIDS key is `DatasetType`, which is also what `utils/bids.py` writes, so rsHRF rejected
   spec-compliant derivative datasets, including its own output. Fixed by @anaharrismatnez in
   #52; the test fixtures were writing the same wrong key, which is why this went unnoticed.
+  `DataType` is still accepted with a warning, since it is the convention older fMRIPrep
+  versions wrote and real derivatives in use still carry it; the dataset the integration
+  test runs on is one of them.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,10 @@ intercept as part of the HRF.
   deliberate: the "Empty or zero time course" warning, the flat-curve warning in `knee_pt`,
   and warnings from dependencies. Voxels excluded for having a flat time course are now reported
   once per run, with a count and the likely cause, instead of warning per voxel.
+* `[Fixed]` The BIDS input check required `DataType` in `dataset_description.json`, but the
+  BIDS key is `DatasetType`, which is also what `utils/bids.py` writes — so rsHRF rejected
+  spec-compliant derivative datasets, including its own output. Fixed by @anaharrismatnez in
+  #52; the test fixtures were writing the same wrong key, which is why this went unnoticed.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/CLI.py
+++ b/rsHRF/CLI.py
@@ -500,16 +500,16 @@ def run_rsHRF():
 
             if fname.exists():
                 desc = json.loads(Path(fname).read_text())
-                if "DataType" in desc:
-                    if desc["DataType"] != "derivative":
+                if "DatasetType" in desc:
+                    if desc["DatasetType"] != "derivative":
                         parser.error(
                             "Input data is not a derivative dataset"
-                            ' (DataType in dataset_description.json is not equal to "derivative")'
+                            ' (DatasetType in dataset_description.json is not equal to "derivative")'
                         )
 
                 else:
                     parser.error(
-                        "DataType is not defined in the dataset_description.json file. Please make sure DataType is defined. "
+                        "DatasetType is not defined in the dataset_description.json file. Please make sure DatasetType is defined. "
                         "Information on the dataset_description.json file can be found online "
                         "(https://bids-specification.readthedocs.io/en/stable/03-modality-agnostic-files.html"
                         "#derived-dataset-and-pipeline-description)"

--- a/rsHRF/CLI.py
+++ b/rsHRF/CLI.py
@@ -522,18 +522,24 @@ def run_rsHRF():
             if fname.exists():
                 desc = json.loads(Path(fname).read_text())
                 if "DatasetType" in desc:
-                    if desc["DatasetType"] != "derivative":
-                        parser.error(
-                            "Input data is not a derivative dataset"
-                            ' (DatasetType in dataset_description.json is not equal to "derivative")'
-                        )
-
+                    data_type = desc["DatasetType"]
+                elif "DataType" in desc:
+                    warnings.warn(
+                        "DataType field is an old fMRIPrep naming convention please use 'DatasetType'",
+                        category=RuntimeWarning,
+                    )
+                    data_type = desc["DataType"]
                 else:
                     parser.error(
                         "DatasetType is not defined in the dataset_description.json file. Please make sure DatasetType is defined. "
                         "Information on the dataset_description.json file can be found online "
                         "(https://bids-specification.readthedocs.io/en/stable/03-modality-agnostic-files.html"
                         "#derived-dataset-and-pipeline-description)"
+                    )
+                if data_type != "derivative":
+                    parser.error(
+                        "Input data is not a derivative dataset"
+                        ' (DatasetType in dataset_description.json is not equal to "derivative")'
                     )
             else:
                 parser.error(

--- a/rsHRF/unit_tests/test_cli.py
+++ b/rsHRF/unit_tests/test_cli.py
@@ -860,7 +860,7 @@ def test_BIDS_bold_in_subject_label(monkeypatch, tmp_path):
     ds = fake_BIDS_dataset(
         tmp_path,
         ["bold01"],
-        {"DataType": "derivative"},
+        {"DatasetType": "derivative"},
         {
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz": "fake",
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json": json.dumps(

--- a/rsHRF/unit_tests/test_cli.py
+++ b/rsHRF/unit_tests/test_cli.py
@@ -884,3 +884,34 @@ def test_BIDS_bold_in_subject_label(monkeypatch, tmp_path):
             )
             CLI.run_rsHRF()
             mock_call.assert_called_once()
+
+
+def test_BIDS_accepts_legacy_DataType(monkeypatch, tmp_path):
+    """An old fMRIPrep derivative that writes DataType is still accepted."""
+    ds = fake_BIDS_dataset(
+        tmp_path,
+        ["01"],
+        {"DataType": "derivative"},
+        {
+            "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz": "fake",
+            "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json": json.dumps(
+                {"TaskName": "Rest", "RepetitionTime": 2}
+            ),
+        },
+    )
+    with mock.patch("rsHRF.fourD_rsHRF.demo_rsHRF") as mock_call:
+        with pytest.warns(RuntimeWarning, match="DataType"):
+            monkeypatch.setattr(
+                sys,
+                "argv",
+                [
+                    "rsHRF",
+                    str(ds / "derivatives" / "fmriprep"),
+                    str(ds / "derivatives" / "rsHRF"),
+                    "participant",
+                    "--TR",
+                    "2",
+                ],
+            )
+            CLI.run_rsHRF()
+            mock_call.assert_called_once()

--- a/rsHRF/unit_tests/test_cli.py
+++ b/rsHRF/unit_tests/test_cli.py
@@ -403,7 +403,7 @@ def test_BIDS(monkeypatch, tmp_path):
     ds = fake_BIDS_dataset(
         tmp_path,
         ["01"],
-        {"DataType": "derivative"},
+        {"DatasetType": "derivative"},
         {
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz": "fake",
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json": json.dumps(
@@ -433,7 +433,7 @@ def test_BIDS_failedComp(monkeypatch, tmp_path):
     ds = fake_BIDS_dataset(
         tmp_path,
         ["01"],
-        {"DataType": "derivative"},
+        {"DatasetType": "derivative"},
         {
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz": "fake",
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json": json.dumps(
@@ -479,7 +479,7 @@ def test_BIDS_TR(monkeypatch, tmp_path):
     ds = fake_BIDS_dataset(
         tmp_path,
         ["01"],
-        {"DataType": "derivative"},
+        {"DatasetType": "derivative"},
         {
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz": "fake",
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json": json.dumps(
@@ -508,7 +508,7 @@ def test_BIDS_nonDerivative(monkeypatch, tmp_path):
     ds = fake_BIDS_dataset(
         tmp_path,
         ["01"],
-        {"DataType": "original"},
+        {"DatasetType": "original"},
         {
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz": "fake",
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json": json.dumps(
@@ -587,7 +587,7 @@ def test_BIDS_participantLabels(monkeypatch, tmp_path):
     ds = fake_BIDS_dataset(
         tmp_path,
         ["01"],
-        {"DataType": "derivative"},
+        {"DatasetType": "derivative"},
         {
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz": "fake",
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json": json.dumps(
@@ -630,7 +630,7 @@ def test_BIDS_mask(monkeypatch, tmp_path):
     ds = fake_BIDS_dataset(
         tmp_path,
         ["01"],
-        {"DataType": "derivative"},
+        {"DatasetType": "derivative"},
         {
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz": "fake",
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json": json.dumps(
@@ -683,7 +683,7 @@ def test_BIDS_mask_bad(monkeypatch, tmp_path):
     ds = fake_BIDS_dataset(
         tmp_path,
         ["01"],
-        {"DataType": "derivative"},
+        {"DatasetType": "derivative"},
         {
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz": "fake",
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json": json.dumps(
@@ -756,7 +756,7 @@ def test_BIDS_filters(monkeypatch, tmp_path):
     ds = fake_BIDS_dataset(
         tmp_path,
         ["01"],
-        {"DataType": "derivative"},
+        {"DatasetType": "derivative"},
         {
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz": "fake",
             "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json": json.dumps(


### PR DESCRIPTION
This PR fixes the lookup of the dataset type in `CLI.py`.

The current implementation searches for the `DataType` field in dataset_description.json. However, according to the BIDS specification, the correct field name is `DatasetType`. 