### PR TITLE
Fix voxel ordering in the generated brain mask

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,14 @@
 * `[Fixed]` `wgr_BOLD_event_vector` converted the 0/1 temporal mask into indices in place, leaving `0` at every dropped position, so each scrubbed frame entered the mean and standard deviation as `matrix[0]` instead of being excluded, and the resulting scale error changed which frames were detected as events. The conversion also wrote through to the caller's list, which `compute_hrf` shares across every voxel. Both are gone: the mask is now read with boolean indexing, the direct equivalent of MATLAB's `matrix(temporal_mask)`. Only runs that pass `--temporal-mask` are affected, and for those the detected events change.
 * `[Fixed]` `estimate_hrf` assumed `para["thr"]` was a scalar, but the GUI's `set_thr` wraps it in a list for FIR/sFIR even when the user types a single number, so `np.array([para["thr"], np.inf])` built a ragged array and raised `ValueError`. Because `main.py` pushes the whole parameter form back through `set_parameters` on every update, this hit any GUI FIR/sFIR run once the user applied parameters, not just comma-separated input. Both branches now use `np.atleast_1d`, which accepts the scalar from the CLI and the list from the GUI; the CLI path is unchanged.
 * `[Fixed]` The Wiener deconvolution read `deconv_MaxIter`, `deconv_Tol` and `deconv_mode` from `para`, but nothing ever set them and there were no CLI arguments, so `.get` always fell back to its hardcoded default and the parameters were unreachable. They are now exposed as `--deconv-maxiter`, `--deconv-tol` and `--deconv-mode`, with the defaults moved into `default_parameters`. Behaviour is unchanged at the defaults. Note that MATLAB's `rsHRF_deconv_job` passes `MaxIter = 10` while Python's default is 50.
+* `[Fixed]` When no mask or atlas was supplied, the generated brain mask was built by
+  flattening the volume in C order (`data.reshape(-1, data.shape[3])`), while the data it
+  indexes is flattened in Fortran order a few lines below. `voxel_ind` therefore pointed at
+  different voxels than the ones that were extracted and written back, so the variance
+  criterion selected the wrong set: some zero-variance voxels were analysed and some real
+  ones were skipped. The mask branch was already consistent, because `spm_read_vols`
+  flattens in Fortran order. Only runs without a mask or atlas are affected, and for those
+  the set of analysed voxels changes.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/fourD_rsHRF.py
+++ b/rsHRF/fourD_rsHRF.py
@@ -81,7 +81,9 @@ def demo_rsHRF(
             print("No atlas provided! Generating mask file...")
             if file_type == ".nii" or file_type == ".nii.gz":
                 data = v1.get_fdata()
-                brain = np.nanvar(data.reshape(-1, data.shape[3]), -1, ddof=0)
+                brain = np.nanvar(
+                    data.reshape(-1, data.shape[3], order="F"), -1, ddof=0
+                )
             else:
                 data = v1.agg_data()
                 brain = np.nanvar(data, -1, ddof=0)

--- a/rsHRF/unit_tests/test_fourD_rsHRF.py
+++ b/rsHRF/unit_tests/test_fourD_rsHRF.py
@@ -1,0 +1,65 @@
+import os
+from copy import deepcopy
+
+import nibabel as nib
+import numpy as np
+from scipy.signal import convolve
+
+from .. import fourD_rsHRF
+from ..spm_dep import spm
+from ..utils import hrf_estimation
+from ..utils.default_parameters import default_parameters
+
+TR = 2.0
+X, Y, Z, nobs = 5, 6, 8, 30
+# Voxels carrying signal, numbered in Fortran order. Chosen so that reading the
+# same numbers in C order picks a disjoint set, which is what makes this test
+# able to fail.
+SIGNAL_VOXELS = [1, 83, 150, 192]
+EVENT_ONSETS = [5, 15, 25]
+
+
+def _write_bold(path):
+    rng = np.random.default_rng(0)
+    hrf = spm.spm_hrf(TR)
+    neural = np.zeros(nobs)
+    neural[EVENT_ONSETS] = 3.0
+    signal = convolve(neural, hrf, mode="full")[:nobs]
+
+    flat = np.zeros((X * Y * Z, nobs))
+    flat[SIGNAL_VOXELS] = signal + rng.normal(0, 0.05, (len(SIGNAL_VOXELS), nobs))
+    data = np.reshape(flat, (X, Y, Z, nobs), order="F")
+    nib.save(nib.Nifti1Image(data, np.eye(4)), path)
+
+
+def _para():
+    para = deepcopy(default_parameters)
+    para["TR"] = TR
+    para["dt"] = para["TR"] / para["T"]
+    para["lag"] = np.arange(
+        np.trunc(para["min_onset_search"] / para["dt"]),
+        np.trunc(para["max_onset_search"] / para["dt"]) + 1,
+        dtype=int,
+    )
+    hrf_estimation.apply_localK_default(para)
+    return para
+
+
+def test_generated_mask_uses_fortran_order(tmp_path):
+    """
+    With no mask supplied, demo_rsHRF builds one from the temporal variance.
+    That variance map has to be flattened the same way as the data itself
+    (Fortran order); flattening it in C order makes voxel_ind point at
+    different voxels than the ones that get extracted, so the analysis
+    silently runs on the wrong voxels.
+    """
+    bold = str(tmp_path / "sub-01_task-rest_bold.nii")
+    _write_bold(bold)
+    out = str(tmp_path / "out")
+
+    fourD_rsHRF.demo_rsHRF(bold, None, out, _para(), 1, file_type=".nii", mode="input")
+
+    height = nib.load(os.path.join(out, "sub-01_task-rest_height.nii"))
+    estimated = np.flatnonzero(height.get_fdata().flatten(order="F"))
+
+    assert estimated.tolist() == SIGNAL_VOXELS


### PR DESCRIPTION
When no mask or atlas is supplied, `demo_rsHRF` generates a brain mask from the
temporal variance. The volume was flattened in C order for that, while the data it
indexes is flattened in Fortran order a few lines below, so `voxel_ind` pointed at
different voxels than the ones extracted. The mask branch was already correct
(`spm_read_vols` flattens in Fortran order).

Not a deliberate choice: `git log -S nanvar` traces the line to `06b7620` (1.2.0,
Aug 2020), a bulk refactor that introduced `order='F'` five other times in this file
and omitted it here once. MATLAB is column-major, so this mismatch can't exist there.

Adds the first test for `fourD_rsHRF.py`; reverting the one-line fix turns it red.

**Output changes** for runs without a mask or atlas — the set of analysed voxels
is now the one the variance criterion actually selects.