### PR TITLE
Restore per-column means in rest_IdealFilter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,14 @@
   ones were skipped. The mask branch was already consistent, because `spm_read_vols`
   flattens in Fortran order. Only runs without a mask or atlas are affected, and for those
   the set of analysed voxels changes.
+  * `[Fixed]` `rest_IdealFilter` restored the mean of the filtered signal with
+  `np.mean(x1)`, which takes no axis and therefore returns a single value for the whole
+  chunk, where MATLAB's `repmat(mean(x1,1), size(x1,1), 1)` restores each column's own
+  mean. Behaviour is unchanged on every current call path — the CLI, the GUI and the
+  consistency test all z-score the data before filtering, so the column means are already
+  zero — but the function now matches MATLAB for callers that pass unstandardised data.
+  Also drops the `np.tile`, since broadcasting the `(1, n)` mean avoids materialising a
+  full-size intermediate array.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/processing/rest_filter.py
+++ b/rsHRF/processing/rest_filter.py
@@ -13,7 +13,7 @@ def rest_IdealFilter(x, TR, Bands, m=5000):
         else:
             ind_X = [j for j in range((i - 1) * m, nvar)]
         x1 = x[:, ind_X]
-        x1 = conn_filter(TR, Bands, x1) + np.tile(np.mean(x1), (x1.shape[0], 1))
+        x1 = conn_filter(TR, Bands, x1) + np.mean(x1, axis=0, keepdims=True)
         x[:, ind_X] = x1
     return x
 

--- a/rsHRF/unit_tests/test_rest_filter.py
+++ b/rsHRF/unit_tests/test_rest_filter.py
@@ -27,3 +27,13 @@ def test_rest_IdealFilter():
     x = np.ones((152, 1))
     y = rest_filter.rest_IdealFilter(x, TR, filter)
     assert np.allclose(y, np.ones((152, 1)))
+
+
+def test_Ideal_filter_adds_unique_column_means():
+    matrix = np.ones((152, 3)) * np.array([10.0, 50.0, 100.0])
+    m_expected = np.mean(matrix, axis=0)
+    TR = 2.0
+    filter = [0.01, 0.08]
+    y = rest_filter.rest_IdealFilter(matrix, TR, filter)
+
+    assert np.allclose(m_expected, np.mean(y, axis=0), rtol=1e-5)


### PR DESCRIPTION
`np.mean(x1)` takes no axis, so it restored a scalar value for the whole chunk where
MATLAB's `repmat(mean(x1,1), size(x1,1), 1)` restores each column's own mean.

Behaviour is unchanged on every current call path; the CLI, the GUI and the
consistency test all z-score before filtering, so column means are already zero
(measured: identical to 0.0000 on z-scored data, diverging by up to 0.24 on raw data).
The fix matters for callers that pass unstandardised data.

Adds a three-column test; the existing one used a single column, where the grand mean
and the column mean are the same number by definition which is why this survived.