### PR TITLE
Append the selected lag to beta_hrf in the FIR path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,14 +31,21 @@
   ones were skipped. The mask branch was already consistent, because `spm_read_vols`
   flattens in Fortran order. Only runs without a mask or atlas are affected, and for those
   the set of analysed voxels changes.
-  * `[Fixed]` `rest_IdealFilter` restored the mean of the filtered signal with
-  `np.mean(x1)`, which takes no axis and therefore returns a single value for the whole
-  chunk, where MATLAB's `repmat(mean(x1,1), size(x1,1), 1)` restores each column's own
-  mean. Behaviour is unchanged on every current call path — the CLI, the GUI and the
-  consistency test all z-score the data before filtering, so the column means are already
-  zero — but the function now matches MATLAB for callers that pass unstandardised data.
-  Also drops the `np.tile`, since broadcasting the `(1, n)` mean avoids materialising a
-  full-size intermediate array.
+* `[Fixed]` `rest_IdealFilter` restored the mean of the filtered signal with
+`np.mean(x1)`, which takes no axis and therefore returns a single value for the whole
+chunk, where MATLAB's `repmat(mean(x1,1), size(x1,1), 1)` restores each column's own
+mean. Behaviour is unchanged on every current call path — the CLI, the GUI and the
+consistency test all z-score the data before filtering, so the column means are already
+zero — but the function now matches MATLAB for callers that pass unstandardised data.
+Also drops the `np.tile`, since broadcasting the `(1, n)` mean avoids materialising a
+full-size intermediate array.
+* `[Fixed]` The FIR/sFIR path did not append the selected lag to `beta_hrf`, although
+MATLAB's `rsHRF_estimation_FIR.m` does and so does the basis path in `wgr_hrf_fit`, so
+the delay chosen for each voxel was discarded and could only be recovered by
+instrumenting `knee_pt`. It is now appended, and the slices that consume `beta_hrf` drop
+two trailing rows instead of one. This also fixes a separate bug in the GUI, where the
+FIR branch passed `beta_hrf` through untouched and therefore treated the regression
+intercept as part of the HRF.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/fourD_rsHRF.py
+++ b/rsHRF/fourD_rsHRF.py
@@ -131,7 +131,7 @@ def demo_rsHRF(
         beta_hrf, event_bold = utils.hrf_estimation.compute_hrf(
             bold_sig, para, temporal_mask, p_jobs
         )
-        hrfa = beta_hrf[:-1, :]
+        hrfa = beta_hrf[:-2, :]
     else:
         bf = basis_functions.basis_functions.get_basis_function(bold_sig.shape, para)
         beta_hrf, event_bold = utils.hrf_estimation.compute_hrf(

--- a/rsHRF/rsHRF_GUI/core/core.py
+++ b/rsHRF/rsHRF_GUI/core/core.py
@@ -330,7 +330,7 @@ class Core:
                 beta_hrf, event_bold = utils.hrf_estimation.compute_hrf(
                     bold_sig, para, [], -1
                 )
-                hrfa = beta_hrf
+                hrfa = beta_hrf[:-2, :]
             else:
                 # estimate HRF for the fourier / hanning / gamma / cannon basis functions
                 bf = basis_functions.basis_functions.get_basis_function(

--- a/rsHRF/sFIR/smooth_fir.py
+++ b/rsHRF/sFIR/smooth_fir.py
@@ -182,4 +182,5 @@ def wgr_FIR_estimation_HRF(u, dat, para, N):
     if ind == np.amax(Cov_E.shape) - 1:
         ind = ind - 1
     rsH = hrf[:, ind + 1]
+    rsH = np.append(rsH, lag[ind + 1])
     return rsH, u

--- a/rsHRF/unit_tests/test_smooth_fir.py
+++ b/rsHRF/unit_tests/test_smooth_fir.py
@@ -406,7 +406,9 @@ def test_wgr_FIR_estimation_HRF():
     out1, out2 = output
     assert type(out1) == type(np.asarray([]))
     assert type(out2) == type(np.asarray([]))
-    assert np.allclose(out1, np.zeros((13)))
+    # the HRF and its intercept, then the selected lag appended last
+    assert np.allclose(out1[:-1], np.zeros((13)))
+    assert out1[-1] in para["lag"]
     out2_exp = np.array(
         [
             0.82657439,


### PR DESCRIPTION
MATLAB's `rsHRF_estimation_FIR.m` appends the chosen delay to `beta_hrf`, and so does
the basis path in `wgr_hrf_fit`, but the Python FIR path dropped it, so the per-voxel
delay was only recoverable by instrumenting `knee_pt`. The consuming slices now drop two
trailing rows instead of one.

Also fixes a separate GUI bug found while mapping the consumers: the FIR branch passed
`beta_hrf` through untouched, so the regression intercept was treated as part of the HRF.

The existing FIR test asserted the whole return was zeros; it now checks the HRF part
separately and that the last element is one of the requested lags.