### PR TITLE
Return a real array from the non-Wiener deconvolution branch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,13 @@ instrumenting `knee_pt`. It is now appended, and the slices that consume `beta_h
 two trailing rows instead of one. This also fixes a separate bug in the GUI, where the
 FIR branch passed `beta_hrf` through untouched and therefore treated the regression
 intercept as part of the HRF.
+* `[Fixed]` The non-Wiener branch of `process_voxel_deconv` returned the raw output of
+  `np.fft.ifft`, which is complex, so assigning it into the real `data_deconv` array
+  discarded the imaginary part implicitly and raised a `ComplexWarning` on every run. The
+  signal and the HRF are both real, so the filtered spectrum is Hermitian and the inverse
+  transform is real up to floating-point error — the numerical output is unchanged. The
+  branch now returns `np.real(...)`, matching the Wiener branch and MATLAB, which takes
+  `real()` at every `ifft`.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/fourD_rsHRF.py
+++ b/rsHRF/fourD_rsHRF.py
@@ -163,8 +163,10 @@ def demo_rsHRF(
                 np.append(hrf, np.zeros((nobs_val - max(hrf.shape), 1))), axis=0
             )
             M = np.fft.fft(sig_deconv[:, voxel_id])
-            return np.fft.ifft(
-                H.conj() * M / (H * H.conj() + 0.1 * np.mean((H * H.conj())))
+            return np.real(
+                np.fft.ifft(
+                    H.conj() * M / (H * H.conj() + 0.1 * np.mean((H * H.conj())))
+                )
             )
         else:
             deconv_mode = p_para.get("deconv_mode", "rest")


### PR DESCRIPTION
`np.fft.ifft` returns a complex array, and assigning it into the real `data_deconv`
discarded the imaginary part implicitly while raising a `ComplexWarning` on every run.

Both the signal and the HRF are real, so the filtered spectrum is Hermitian and the
inverse transform is real up to floating-point error, so the numerical output is unchanged.
The point is that NumPy's implicit cast behaves the same whether the imaginary part is
rounding noise or real signal, so the correctness here was incidental rather than stated.

This matches the Wiener branch and MATLAB, which takes `real()` at every `ifft`.

