### PR TITLE
Carry the FIR microtime correction on the HRF object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,13 @@ intercept as part of the HRF.
   transform is real up to floating-point error — the numerical output is unchanged. The
   branch now returns `np.real(...)`, matching the Wiener branch and MATLAB, which takes
   `real()` at every `ifft`.
+* `[Fixed]` The GUI applied the FIR/sFIR microtime correction to a local dictionary but
+  stored the uncorrected `Parameters` object on the HRF, so every later consumer read
+  `T = 3` for an HRF that was estimated at `T = 1`. `deconvolveHRF` therefore resampled an
+  HRF that was already at TR resolution by a further factor of `T`, and `getHRFParameters`
+  computed response height, time-to-peak and FWHM against a `dt` three times too small.
+  The corrected parameters now travel with the HRF, which fixes both consumers. The shared
+  parameter form is left untouched, so switching back to a basis set still uses `T = 3`.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/rsHRF_GUI/core/core.py
+++ b/rsHRF/rsHRF_GUI/core/core.py
@@ -1,4 +1,5 @@
 import os
+import copy
 import numpy as np
 import nibabel as nib
 import scipy.io as sio
@@ -326,6 +327,8 @@ class Core:
             utils.hrf_estimation.apply_localK_default(para)
             if para["estimation"] == "sFIR" or para["estimation"] == "FIR":
                 utils.hrf_estimation.apply_fir_microtime_grid(para)
+                run_para = copy.deepcopy(self.parameters)
+                run_para.set_T(1)
                 # estimate HRF for FIR and sFIR
                 beta_hrf, event_bold = utils.hrf_estimation.compute_hrf(
                     bold_sig, para, [], -1
@@ -333,6 +336,7 @@ class Core:
                 hrfa = beta_hrf[:-2, :]
             else:
                 # estimate HRF for the fourier / hanning / gamma / cannon basis functions
+                run_para = self.parameters
                 bf = basis_functions.basis_functions.get_basis_function(
                     bold_sig.shape, para
                 )  # obtaining the basis set
@@ -341,9 +345,7 @@ class Core:
                 )
                 hrfa = np.dot(bf, beta_hrf[np.arange(0, bf.shape[1]), :])
             # instantiating the time-series objects
-            hrf = HRF(
-                label="HRF", ts=hrfa, subject_index=subject_index, para=self.parameters
-            )
+            hrf = HRF(label="HRF", ts=hrfa, subject_index=subject_index, para=run_para)
             # the HRF is associated to a particular Preprocessed BOLD Time-series
             hrf.set_BOLD(bold_pre_ts)
             hrf.set_event_bold(event_bold)  # setting the bold-events
@@ -417,7 +419,7 @@ class Core:
     def deconvolveHRF(self, hrf):
         """
         Retrieves the Deconvolved BOLD Time-series
-        with HRF as input, and self.parameters as the parameters
+        with HRF as input, and hrf.parameters as the parameters
         """
         subject_index = (
             hrf.get_subject_index()
@@ -425,7 +427,7 @@ class Core:
         subject = self.dataStore.get_subject_by_index(
             subject_index
         )  # gets the subject from the index
-        para = self.parameters.get_parameters()
+        para = hrf.get_parameters().get_parameters()
         # if the HRF has already been retrieved for this particular set of inputs
         if not subject.is_present("Deconvolved-BOLD", (self.parameters, hrf)):
             # inputs for retrieving the deconvolved BOLD


### PR DESCRIPTION
`retrieveHRF` applied `apply_fir_microtime_grid` to a local dict but passed the
uncorrected `Parameters` object to `HRF()`, so the correction never reached
`deconvolveHRF` or `getHRFParameters`. Both read `T = 3` for an HRF estimated at `T = 1`:
the first resampled an HRF already at TR resolution by a further factor of `T`, the second
computed response height, time-to-peak and FWHM against a `dt` three times too small.

The FIR branch now stores a deepcopy with `set_T(1)`, which cascades through `update_dt`
and `update_lag`, and `deconvolveHRF` reads the parameters from the HRF. The shared
parameter form is not mutated, so switching back to a basis set still uses `T = 3`.

