### PR TITLE
Split on the last occurrence of "bold" when reading file extension.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -60,6 +60,11 @@ intercept as part of the HRF.
   computed response height, time-to-peak and FWHM against a `dt` three times too small.
   The corrected parameters now travel with the HRF, which fixes both consumers. The shared
   parameter form is left untouched, so switching back to a basis set still uses `T = 3`.
+* `[Fixed]` The BIDS loop extracted the file extension with `split("bold")[1]`, which takes
+  the text after the *first* occurrence of "bold". Any path with an earlier "bold", for example a
+  participant label like `sub-bold01`, or a parent directory named `bold` returned a path
+  fragment instead of an extension, so the file fell through to the GIfTI branch and was
+  counted as an error. It now splits on the last occurrence.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/CLI.py
+++ b/rsHRF/CLI.py
@@ -667,7 +667,7 @@ def run_rsHRF():
 
             num_errors = 0
             for file_count in range(len(all_inputs)):
-                file_type = all_inputs[file_count].split("bold")[1]
+                file_type = all_inputs[file_count].rsplit("bold", 1)[-1]
                 if file_type == ".nii" or file_type == ".nii.gz":
                     try:
                         TR = layout.get_metadata(all_inputs[file_count])[

--- a/rsHRF/unit_tests/test_cli.py
+++ b/rsHRF/unit_tests/test_cli.py
@@ -853,3 +853,34 @@ def test_temporal_mask_accepts_valid_formats(monkeypatch, tmp_path):
             )
             CLI.run_rsHRF()
             mock_call.assert_called_once()
+
+
+def test_BIDS_bold_in_subject_label(monkeypatch, tmp_path):
+    """A participant label containing "bold" must not break extension parsing."""
+    ds = fake_BIDS_dataset(
+        tmp_path,
+        ["bold01"],
+        {"DataType": "derivative"},
+        {
+            "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz": "fake",
+            "sub-{}_task-rest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json": json.dumps(
+                {"TaskName": "Rest", "RepetitionTime": 2}
+            ),
+        },
+    )
+    with mock.patch("rsHRF.fourD_rsHRF.demo_rsHRF") as mock_call:
+        with pytest.warns(Warning):
+            monkeypatch.setattr(
+                sys,
+                "argv",
+                [
+                    "rsHRF",
+                    str(ds / "derivatives" / "fmriprep"),
+                    str(ds / "derivatives" / "rsHRF"),
+                    "participant",
+                    "--TR",
+                    "2",
+                ],
+            )
+            CLI.run_rsHRF()
+            mock_call.assert_called_once()


### PR DESCRIPTION
`split("bold)[1]` captures the text after the first occurrence of "bold" in the given file path. So any path that included an earlier occurence of "bold" was cut faulty. For example, a parent directory named "bold" could potentially  capture a path fragment rather than the file extension. The added test is test_BIDS with a participant label containing "bold".