### PR TITLE
Fix __all__ in the package __init__

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,11 @@ intercept as part of the HRF.
   participant label like `sub-bold01`, or a parent directory named `bold` returned a path
   fragment instead of an extension, so the file fell through to the GIfTI branch and was
   counted as an error. It now splits on the last occurrence.
+* `[Fixed]` `__all__` in `rsHRF/__init__.py` listed `"fourD_rsHRF.py"` and `"CLI.py"` with
+  their file extensions, so `from rsHRF import *` raised `AttributeError`; `__all__` takes
+  module names, not filenames. `utils`, `basis_functions` and `iterative_wiener_deconv` are
+  now imported explicitly as well, because they were only reachable as a side effect of other
+  modules importing them, so `__all__` would have broken again if those imports changed.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/__init__.py
+++ b/rsHRF/__init__.py
@@ -3,6 +3,9 @@ import rsHRF.processing
 import rsHRF.canon
 import rsHRF.sFIR
 import rsHRF.parameters
+import rsHRF.utils
+import rsHRF.basis_functions
+import rsHRF.iterative_wiener_deconv
 import rsHRF.fourD_rsHRF
 import rsHRF.CLI
 
@@ -10,11 +13,11 @@ __all__ = [
     "spm_dep",
     "processing",
     "canon",
-    "utils",
     "sFIR",
     "parameters",
+    "utils",
     "basis_functions",
-    "fourD_rsHRF.py",
-    "CLI.py",
     "iterative_wiener_deconv",
+    "fourD_rsHRF",
+    "CLI",
 ]

--- a/rsHRF/unit_tests/test_module_imports.py
+++ b/rsHRF/unit_tests/test_module_imports.py
@@ -1,0 +1,8 @@
+import rsHRF
+
+
+def test_rsHRF_does_not_import_an_attribute_that_does_not_exist():
+    missing_attr = [a for a in rsHRF.__all__ if not hasattr(rsHRF, a)]
+    assert (
+        len(missing_attr) == 0
+    ), f"rsHRF does not have the following attributes:{missing_attr}"


### PR DESCRIPTION
__all__ listed "fourD_rsHRF.py" and "CLI.py" with their file extensions, so from rsHRF import * raised AttributeError; __all__ takes module names, not filenames.

utils, basis_functions and iterative_wiener_deconv are now imported explicitly too. They were only reachable as a side effect of other modules importing them, so __all__ would have broken again if those imports changed. The added test walks __all__ and reports every name that is not an attribute of the package.