### PR TITLE
Use the HRF's parameters consistently in deconvolveHRF

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,6 +70,12 @@ intercept as part of the HRF.
   module names, not filenames. `utils`, `basis_functions` and `iterative_wiener_deconv` are
   now imported explicitly as well, because they were only reachable as a side effect of other
   modules importing them, so `__all__` would have broken again if those imports changed.
+* `[Fixed]` `deconvolveHRF` looked its cache entry up with the shared parameter form but
+  stored it with the HRF's own parameters, so once the two diverged the check never matched.
+  Since `add_BOLD_deconv` appends, deconvolving the same HRF twice added a duplicate entry
+  to the data store instead of returning "Time series already exists", and recomputed the
+  per-voxel deconvolution. `TR` and the deconvolution passband were also read from the form
+  rather than the HRF. All four now come from the HRF, so the lookup and the stored key match.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/rsHRF_GUI/core/core.py
+++ b/rsHRF/rsHRF_GUI/core/core.py
@@ -427,16 +427,17 @@ class Core:
         subject = self.dataStore.get_subject_by_index(
             subject_index
         )  # gets the subject from the index
-        para = hrf.get_parameters().get_parameters()
+        hrf_para = hrf.get_parameters()
+        para = hrf_para.get_parameters()
         # if the HRF has already been retrieved for this particular set of inputs
-        if not subject.is_present("Deconvolved-BOLD", (self.parameters, hrf)):
+        if not subject.is_present("Deconvolved-BOLD", (hrf_para, hrf)):
             # inputs for retrieving the deconvolved BOLD
             hrfa = hrf.get_ts()
             bold_sig = hrf.get_associated_BOLD().get_ts()
             bold_sig = processing.rest_filter.rest_IdealFilter(
                 bold_sig,
-                self.parameters.get_TR(),
-                self.parameters.get_passband_deconvolve(),
+                hrf_para.get_TR(s),
+                hrf_para.get_passband_deconvolve(),
             )
             event_bold = hrf.get_event_bold()
             nvar = hrfa.shape[1]


### PR DESCRIPTION
The cache lookup passed `self.parameters` while the stored entry was created with `hrf.get_parameters()`, so once the two diverged the check never matched. Since `add_BOLD_deconv` appends, deconvolving the same HRF twice added a duplicate entry to the data store instead of returning "Time series already exists", and recomputed the per-voxel deconvolution. TR and the deconvolution passband were also read from the form rather than the HRF.

All four sites now read from the HRF's Parameters object, held in a local so the object and its dict form are not confused.