### PR TITLE
Cover the expected numerical warnings with errstate

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,14 @@ intercept as part of the HRF.
 * `[Changed]` CI now uses the up-to-date `cimg/python:3.9` image. The legacy `circleci/*`
   convenience images were retired at the end of 2021 and CircleCI raises a deprecation
   warning for them; the Python version is unchanged.
+* `[Changed]` The expected numerical warnings in `knee_pt_helper` and `spm_hrf` are now
+  covered by `np.errstate` instead of being emitted on every call. In `knee_pt_helper` the
+  first element of `det` is always zero, because a line cannot be fitted through the single
+  point of the first cumulative sum, and that element is never read. In `spm_hrf` the
+  logarithm receives a negative argument when the onset is shifted to build the time
+  derivative, which `np.nan_to_num` already handles. Together these accounted for four
+  warnings per voxel, so a real run emitted hundreds of thousands of them once the blanket
+  suppression is removed. The `knee_pt` flat-curve warning is deliberately left in place.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/processing/knee.py
+++ b/rsHRF/processing/knee.py
@@ -57,10 +57,16 @@ def knee_pt_helper(y, x=None):
             sigma_xx = np.cumsum(np.multiply(x, x), axis=0)
             n = np.arange(1, np.amax(y.shape) + 1).conj().T
             det = np.multiply(n, sigma_xx) - np.multiply(sigma_x, sigma_x)
-            mfwd = (np.multiply(n, sigma_xy) - np.multiply(sigma_x, sigma_y)) / det
-            bfwd = -1 * (
-                (np.multiply(sigma_x, sigma_xy) - np.multiply(sigma_xx, sigma_y)) / det
-            )
+            # det[0] is always 0 because there is only one
+            # point in the first step of cumulative summation and a line cannot pass through
+            # single point. It is safe to silence the warning because det[0] is never read,
+            # as the error_curve loop starts from index 1.
+            with np.errstate(divide="ignore", invalid="ignore"):
+                mfwd = (np.multiply(n, sigma_xy) - np.multiply(sigma_x, sigma_y)) / det
+                bfwd = -1 * (
+                    (np.multiply(sigma_x, sigma_xy) - np.multiply(sigma_xx, sigma_y))
+                    / det
+                )
 
             sigma_xy = np.cumsum(np.multiply(x[::-1], y[::-1]), axis=0)
             sigma_x = np.cumsum(x[::-1], axis=0)
@@ -68,16 +74,21 @@ def knee_pt_helper(y, x=None):
             sigma_xx = np.cumsum(np.multiply(x[::-1], x[::-1]), axis=0)
             n = np.arange(1, np.amax(y.shape) + 1).conj().T
             det = np.multiply(n, sigma_xx) - np.multiply(sigma_x, sigma_x)
-            mbck = ((np.multiply(n, sigma_xy) - np.multiply(sigma_x, sigma_y)) / det)[
-                ::-1
-            ]
-            bbck = (
-                -1
-                * (
-                    (np.multiply(sigma_x, sigma_xy) - np.multiply(sigma_xx, sigma_y))
-                    / det
-                )
-            )[::-1]
+            # same reason as above
+            with np.errstate(divide="ignore", invalid="ignore"):
+                mbck = (
+                    (np.multiply(n, sigma_xy) - np.multiply(sigma_x, sigma_y)) / det
+                )[::-1]
+                bbck = (
+                    -1
+                    * (
+                        (
+                            np.multiply(sigma_x, sigma_xy)
+                            - np.multiply(sigma_xx, sigma_y)
+                        )
+                        / det
+                    )
+                )[::-1]
 
             error_curve = np.full(y.shape, np.nan)
             for breakpt in range(1, np.amax((y - 1).shape)):

--- a/rsHRF/spm_dep/spm.py
+++ b/rsHRF/spm_dep/spm.py
@@ -92,7 +92,9 @@ def spm_hrf(RT, P=None, fMRI_T=16):
     # modelled hemodynamic response function - {mixture of Gammas}
     dt = RT / float(fMRI_T)
     u = np.arange(0, int(p[6] / dt + 1)) - p[5] / dt
-    with np.errstate(divide="ignore"):  # Known division-by-zero
+    # Known division-by-zero and a negative value for logarithm's argument is invalid.
+    # Negative value occurs when onset is shifted for the time derivative.
+    with np.errstate(divide="ignore", invalid="ignore"):
         hrf = (
             _spm_Gpdf(u, p[0] / p[2], dt / p[2])
             - _spm_Gpdf(u, p[1] / p[3], dt / p[3]) / p[4]


### PR DESCRIPTION
`knee_pt_helper` and `spm_hrf` each emit `RuntimeWarnings` on every call, by construction rather than because of the data.

In `knee_pt_helper`, `det[0]` is always zero: the first element of the cumulative sums holds a single point, and a line cannot be fitted through one point. That element is never read, because the `error_curve` loop starts at index 1.

In `spm_hrf`, the logarithm receives a negative argument when the onset is shifted to build the time derivative. `np.nan_to_num` already clears the resulting NaNs a few lines below.

Together these were four warnings per voxel, so a full run would emit hundreds of thousands of them once the blanket suppression in #29 is lifted. The flat-curve warning in `knee_pt` is deliberately left alone, since it is data dependent and signals a degenerate residual curve.