### PR TITLE
Exclude flat-time-course voxels from the analysis

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,7 +87,15 @@ intercept as part of the HRF.
   derivative, which `np.nan_to_num` already handles. Together these accounted for four
   warnings per voxel, so a real run emitted hundreds of thousands of them once the blanket
   suppression is removed. The `knee_pt` flat-curve warning is deliberately left in place.
-
+* `[Fixed]` A supplied mask that is looser than the data let voxels with a flat time course
+  into the analysis, the case reported in #29, where an earlier preprocessing step had
+  masked more tightly than rsHRF does. Those voxels carry no signal, and dividing by their
+  all-zero HRF wrote `nan` into the deconvolved output, while the parameter maps were
+  already zero for them. `voxel_ind` now requires non-zero temporal variance as well as mask
+  membership, which is what the generated-mask branch has always done. Measured on synthetic
+  data: the `nan` count in the deconvolved output goes from 3660 to 0, and every value for
+  voxels that carry signal is unchanged.
+  
 # rsHRF 1.5.8
 ## 12th September, 2021
 * `[Fixed]` Fixed bugs for rest_filter (was only estimating the first 5000 voxels.)

--- a/NEWS.md
+++ b/NEWS.md
@@ -95,7 +95,7 @@ intercept as part of the HRF.
   membership, which is what the generated-mask branch has always done. Measured on synthetic
   data: the `nan` count in the deconvolved output goes from 3660 to 0, and every value for
   voxels that carry signal is unchanged.
-  
+
 # rsHRF 1.5.8
 ## 12th September, 2021
 * `[Fixed]` Fixed bugs for rest_filter (was only estimating the first 5000 voxels.)

--- a/rsHRF/fourD_rsHRF.py
+++ b/rsHRF/fourD_rsHRF.py
@@ -88,7 +88,14 @@ def demo_rsHRF(
                 data = v1.agg_data()
                 brain = np.nanvar(data, -1, ddof=0)
             print("Done")
-        voxel_ind = np.where(brain > 0)[0]
+
+        # A supplied mask can be looser than the data it is applied to, letting
+        # voxels with a flat time course into the analysis. They carry no signal,
+        # and dividing by their all-zero HRF writes nan into the deconvolved map.
+        temporal_variance = np.nanvar(
+            np.reshape(data, (-1, data.shape[-1]), order="F"), -1, ddof=0
+        )
+        voxel_ind = np.where((brain > 0) & (temporal_variance > 0))[0]
         mask_shape = data.shape[:-1]
         nobs = data.shape[-1]
         data1 = np.reshape(data, (-1, nobs), order="F").T


### PR DESCRIPTION
A supplied mask can be looser than the data it is applied to, which is the case Giulio reported in #29: voxels that a tighter preprocessing mask had already zeroed still entered the analysis. They carry no signal, and dividing by their all-zero HRF wrote nan into the deconvolved map, while the parameter maps were already zero for them.

`voxel_ind` now requires non-zero temporal variance as well as mask membership, which is what the generated-mask branch has always done.