### PR TITLE
Fix/warnings sweep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip3 install -r requirements.txt
-            pytest rsHRF/unit_tests/ -p no:warnings
+            pytest rsHRF/unit_tests/
       - run:
           name: run integration test
           command: |

--- a/NEWS.md
+++ b/NEWS.md
@@ -101,7 +101,8 @@ intercept as part of the HRF.
   ones in `knee_pt_helper` and `spm_hrf` are now covered by `np.errstate`, and voxels with a
   flat time course no longer enter the analysis.What remains visible is 
   deliberate: the "Empty or zero time course" warning, the flat-curve warning in `knee_pt`, 
-  and warnings from dependencies.
+  and warnings from dependencies. Voxels excluded for having a flat time course are now reported 
+  once per run, with a count and the likely cause, instead of warning per voxel.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/NEWS.md
+++ b/NEWS.md
@@ -95,6 +95,13 @@ intercept as part of the HRF.
   membership, which is what the generated-mask branch has always done. Measured on synthetic
   data: the `nan` count in the deconvolved output goes from 3660 to 0, and every value for
   voxels that carry signal is unchanged.
+* `[Changed]` Removed the blanket `warnings.filterwarnings("ignore")` from all ten modules
+  that set it, and the `-p no:warnings` flag from the CI test run -the policy asked about
+  in #29-. The warnings that this exposed were dealt with at the source first: the structural
+  ones in `knee_pt_helper` and `spm_hrf` are now covered by `np.errstate`, and voxels with a
+  flat time course no longer enter the analysis.What remains visible is 
+  deliberate: the "Empty or zero time course" warning, the flat-curve warning in `knee_pt`, 
+  and warnings from dependencies.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/NEWS.md
+++ b/NEWS.md
@@ -99,9 +99,9 @@ intercept as part of the HRF.
   that set it, and the `-p no:warnings` flag from the CI test run -the policy asked about
   in #29-. The warnings that this exposed were dealt with at the source first: the structural
   ones in `knee_pt_helper` and `spm_hrf` are now covered by `np.errstate`, and voxels with a
-  flat time course no longer enter the analysis.What remains visible is 
-  deliberate: the "Empty or zero time course" warning, the flat-curve warning in `knee_pt`, 
-  and warnings from dependencies. Voxels excluded for having a flat time course are now reported 
+  flat time course no longer enter the analysis.What remains visible is
+  deliberate: the "Empty or zero time course" warning, the flat-curve warning in `knee_pt`,
+  and warnings from dependencies. Voxels excluded for having a flat time course are now reported
   once per run, with a count and the likely cause, instead of warning per voxel.
 
 # rsHRF 1.5.8

--- a/rsHRF/basis_functions/basis_functions.py
+++ b/rsHRF/basis_functions/basis_functions.py
@@ -3,10 +3,6 @@ import numpy as np
 from scipy.stats import gamma
 from rsHRF import canon, spm_dep, sFIR
 
-import warnings
-
-warnings.filterwarnings("ignore")
-
 """
 BASIS FUNCTION COMPUTATION
 """

--- a/rsHRF/canon/canon_hrf2dd.py
+++ b/rsHRF/canon/canon_hrf2dd.py
@@ -1,10 +1,6 @@
 import numpy as np
 from ..spm_dep import spm
 
-import warnings
-
-warnings.filterwarnings("ignore")
-
 
 def wgr_spm_get_canonhrf(xBF):
     dt = xBF["dt"]

--- a/rsHRF/fourD_rsHRF.py
+++ b/rsHRF/fourD_rsHRF.py
@@ -18,9 +18,6 @@ from rsHRF import (
     iterative_wiener_deconv,
 )
 from joblib import Parallel, delayed
-import warnings
-
-warnings.filterwarnings("ignore")
 
 
 def demo_rsHRF(

--- a/rsHRF/fourD_rsHRF.py
+++ b/rsHRF/fourD_rsHRF.py
@@ -18,6 +18,7 @@ from rsHRF import (
     iterative_wiener_deconv,
 )
 from joblib import Parallel, delayed
+import warnings
 
 
 def demo_rsHRF(
@@ -93,6 +94,15 @@ def demo_rsHRF(
             np.reshape(data, (-1, data.shape[-1]), order="F"), -1, ddof=0
         )
         voxel_ind = np.where((brain > 0) & (temporal_variance > 0))[0]
+        dead_voxels = int(np.sum((brain > 0) & (temporal_variance == 0)))
+        if dead_voxels > 0:
+            warnings.warn(
+                f"{dead_voxels} of {int(np.sum(brain > 0))} voxels in the mask have a "
+                "flat time course and were excluded; the mask is probably looser "
+                "than the data it was applied to.",
+                RuntimeWarning,
+            )
+
         mask_shape = data.shape[:-1]
         nobs = data.shape[-1]
         data1 = np.reshape(data, (-1, nobs), order="F").T

--- a/rsHRF/parameters.py
+++ b/rsHRF/parameters.py
@@ -1,8 +1,6 @@
 import numpy as np
 import warnings
 
-warnings.filterwarnings("ignore")
-
 
 def wgr_get_parameters(hdrf, dt):
     """

--- a/rsHRF/processing/knee.py
+++ b/rsHRF/processing/knee.py
@@ -1,7 +1,4 @@
 import numpy as np
-import warnings
-
-warnings.filterwarnings("ignore")
 
 
 def knee_pt(y):

--- a/rsHRF/processing/rest_filter.py
+++ b/rsHRF/processing/rest_filter.py
@@ -1,7 +1,4 @@
 import numpy as np
-import warnings
-
-warnings.filterwarnings("ignore")
 
 
 def rest_IdealFilter(x, TR, Bands, m=5000):

--- a/rsHRF/rsHRF_GUI/core/core.py
+++ b/rsHRF/rsHRF_GUI/core/core.py
@@ -17,10 +17,6 @@ from ..datatypes.misc.subject import Subject
 from ..datatypes.misc.store import Store
 from ..misc.status import Status
 
-import warnings
-
-warnings.filterwarnings("ignore")
-
 
 class Core:
     """

--- a/rsHRF/sFIR/smooth_fir.py
+++ b/rsHRF/sFIR/smooth_fir.py
@@ -2,10 +2,6 @@ import numpy as np
 from scipy import linalg
 from ..processing import knee
 
-import warnings
-
-warnings.filterwarnings("ignore")
-
 
 def wgr_regress(y, X):
     n, ncolX = X.shape

--- a/rsHRF/spm_dep/spm.py
+++ b/rsHRF/spm_dep/spm.py
@@ -3,10 +3,6 @@ import numpy as np
 import nibabel as nib
 from scipy.special import gammaln
 
-import warnings
-
-warnings.filterwarnings("ignore")
-
 
 def spm_vol(input_file):
     """

--- a/rsHRF/utils/hrf_estimation.py
+++ b/rsHRF/utils/hrf_estimation.py
@@ -9,10 +9,6 @@ from joblib import Parallel, delayed
 from rsHRF import processing, sFIR
 from ..processing import knee
 
-import warnings
-
-warnings.filterwarnings("ignore")
-
 
 def apply_fir_microtime_grid(para):
     """


### PR DESCRIPTION
Closes #29.

Ten modules called `warnings.filterwarnings("ignore")` at import, which is process global,
so anything a user might need to see was hidden. CI also passed `-p no:warnings`. Both are
gone.

The warnings this would have exposed were handled at the source in #63 and #64 rather than
filtered, so no targeted filter was needed here.

The second commit adds the aggregation asked for in the issue: the mask is the user's
input, so silently analysing fewer voxels than it asks for is information they need.
Discarded voxels are now reported once per run, with a count and the likely cause, instead
of per voxel. Nothing is emitted when none are discarded.

What stays visible is deliberate: the "Empty or zero time course" warning, the flat-curve
warning in `knee_pt` (data-dependent, and a real diagnostic signal), and warnings from
dependencies. The test suite passes with 6 warnings, all in that category.