### PR TITLE
Exclude constant columns from text input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -110,6 +110,11 @@ intercept as part of the HRF.
   `DataType` is still accepted with a warning, since it is the convention older fMRIPrep
   versions wrote and real derivatives in use still carry it; the dataset the integration
   test runs on is one of them.
+* `[Fixed]` The text-input path had no equivalent of `voxel_ind`, so a constant column was
+  analysed like any other: it warned four times per column and wrote `nan` into
+  `data_deconv`. Constant columns are now excluded, reported once per run with a count, and
+  the saved arrays are expanded back to the input width so the columns still line up with
+  the input file.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/fourD_rsHRF.py
+++ b/rsHRF/fourD_rsHRF.py
@@ -114,8 +114,18 @@ def demo_rsHRF(
         if data1.ndim == 1:
             data1 = np.expand_dims(data1, axis=1)
         nobs = data1.shape[0]
-        bold_sig = stats.zscore(data1, ddof=1)
+        orig_col_num = data1.shape[1]
+        col_var = np.nanvar(data1, axis=0, ddof=0)
+        voxel_ind = np.where(col_var > 0)[0]
+        bold_sig = stats.zscore(data1[:, voxel_ind], ddof=1)
 
+        discarded = int(np.sum(col_var == 0))
+        if discarded > 0:
+            warnings.warn(
+                f"{discarded} of {orig_col_num} columns in the input file "
+                "are constant and were excluded.",
+                RuntimeWarning,
+            )
     if len(temporal_mask) > 0 and len(temporal_mask) != nobs:
         raise ValueError(
             "Inconsistency in temporal_mask dimensions.\n"
@@ -223,8 +233,26 @@ def demo_rsHRF(
     dic = {"para": para, "hrfa": hrfa, "event_bold": event_bold, "PARA": PARA}
     ext = "_hrf.mat"
     if mode == "time-series":
-        dic["event_number"] = event_number
-        dic["data_deconv"] = data_deconv
+        hrfa_full = np.zeros([hrfa.shape[0], orig_col_num])
+        PARA_full = np.zeros([3, orig_col_num])
+        data_deconv_full = np.zeros([nobs, orig_col_num])
+        event_number_full = np.zeros([1, orig_col_num])
+        event_bold_full = np.empty(orig_col_num, dtype=object)
+
+        hrfa_full[:, voxel_ind] = hrfa
+        PARA_full[:, voxel_ind] = PARA
+        data_deconv_full[:, voxel_ind] = data_deconv
+        event_number_full[:, voxel_ind] = event_number
+        for i in range(orig_col_num):
+            event_bold_full[i] = np.array([], dtype=int)
+        for i, idx in enumerate(voxel_ind):
+            event_bold_full[idx] = event_bold[i]
+
+        dic["hrfa"] = hrfa_full
+        dic["PARA"] = PARA_full
+        dic["data_deconv"] = data_deconv_full
+        dic["event_number"] = event_number_full
+        dic["event_bold"] = event_bold_full
         ext = "_hrf_deconv.mat"
 
     name = name.rsplit("_bold", 1)[0]

--- a/rsHRF/unit_tests/test_fourD_rsHRF.py
+++ b/rsHRF/unit_tests/test_fourD_rsHRF.py
@@ -2,6 +2,8 @@ import os
 from copy import deepcopy
 
 import nibabel as nib
+import pytest
+import scipy.io as sio
 import numpy as np
 from scipy.signal import convolve
 
@@ -17,6 +19,8 @@ X, Y, Z, nobs = 5, 6, 8, 30
 # able to fail.
 SIGNAL_VOXELS = [1, 83, 150, 192]
 EVENT_ONSETS = [5, 15, 25]
+SIGNAL_COLUMNS = [2, 5, 7]
+NCOL = 10
 
 
 def _write_bold(path):
@@ -63,3 +67,48 @@ def test_generated_mask_uses_fortran_order(tmp_path):
     estimated = np.flatnonzero(height.get_fdata().flatten(order="F"))
 
     assert estimated.tolist() == SIGNAL_VOXELS
+
+
+def _write_text(path):
+    """A table where only SIGNAL_COLUMNS vary; each gets a different number
+    of events, so event_bold is exercised both as a 1-D object array and as
+    the 2-D array numpy collapses to when the lengths happen to match."""
+    rng = np.random.default_rng(0)
+    hrf = spm.spm_hrf(TR)
+    hrf = hrf / hrf.max()
+    data = np.zeros((nobs, NCOL))
+    for count, column in enumerate(SIGNAL_COLUMNS):
+        neural = np.zeros(nobs)
+        neural[EVENT_ONSETS[: count + 1]] = 3.0
+        data[:, column] = convolve(neural, hrf, mode="full")[:nobs] + rng.normal(
+            0, 0.05, nobs
+        )
+    np.savetxt(path, data, delimiter=",")
+
+
+def test_constant_columns_are_excluded_without_shifting(tmp_path):
+    """
+    Text input has no mask, so a constant column is analysed unless it is
+    excluded explicitly. Excluding it must not change the width of the saved
+    arrays, or the columns no longer line up with the input file.
+    """
+    text = str(tmp_path / "sub-01_task-rest_bold.txt")
+    _write_text(text)
+    out = str(tmp_path / "out")
+
+    with pytest.warns(RuntimeWarning, match="constant"):
+        fourD_rsHRF.demo_rsHRF(
+            text, None, out, _para(), 1, file_type=".txt", mode="time-series"
+        )
+
+    saved = [f for f in os.listdir(out) if f.endswith(".mat")]
+    assert len(saved) == 1
+    result = sio.loadmat(os.path.join(out, saved[0]))
+
+    for key in ("PARA", "data_deconv", "hrfa", "event_number"):
+        array = np.asarray(result[key])
+        assert array.shape[1] == NCOL
+        assert not np.isnan(array).any()
+        assert sorted(set(np.nonzero(array)[1].tolist())) == SIGNAL_COLUMNS
+
+    assert np.asarray(result["event_bold"]).shape[1] == NCOL


### PR DESCRIPTION
The image path drops voxels with no temporal variance, but the text path
had no equivalent: every column was analysed, so a constant one warned
four times and its all-zero HRF put nan into data_deconv.

Constant columns are now excluded and reported once per run. Because the
text path saves arrays at the processed width rather than writing back
into a full-size volume, the saved arrays are expanded back to the input
width, so column N of the output still corresponds to column N of the
input.
