### PR TITLE
Drop the unused upper bound from thr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -115,6 +115,12 @@ intercept as part of the HRF.
   `data_deconv`. Constant columns are now excluded, reported once per run with a count, and
   the saved arrays are expanded back to the input width so the columns still line up with
   the input file.
+* `[Changed]` `estimate_hrf` appended `np.inf` to `thr` in the FIR/sFIR branch, but only
+  `thr[0]` was read. Both that and the docstring of `wgr_BOLD_event_vector`, which
+  described an `event < 3.1` upper bound, trace back to a line that is commented out in
+  MATLAB's `rsHRF_find_event_vector.m`. The upper bound was never implemented in Python;
+  the docstring now outlines what the function does, which is to detect local peaks above
+  the threshold, the same condition MATLAB implements.
 
 # rsHRF 1.5.8
 ## 12th September, 2021

--- a/rsHRF/utils/hrf_estimation.py
+++ b/rsHRF/utils/hrf_estimation.py
@@ -71,9 +71,7 @@ def estimate_hrf(bold_sig, i, para, N, bf=None):
     localK = para["localK"]
     if para["estimation"] == "sFIR" or para["estimation"] == "FIR":
         # Estimate HRF for the sFIR or FIR basis functions
-        thr = np.append(
-            np.atleast_1d(para["thr"]), np.inf
-        )  # the CLI gives a scalar, the GUI a list
+        thr = np.atleast_1d(para["thr"])  # the CLI gives a scalar, the GUI a list
         u = wgr_BOLD_event_vector(N, dat, thr, localK, para["temporal_mask"])
         u = u.toarray().flatten("C").ravel().nonzero()[0]
         beta_hrf, event_bold = sFIR.smooth_fir.wgr_FIR_estimation_HRF(u, dat, para, N)
@@ -144,8 +142,11 @@ def wgr_hrf_fit(dat, xBF, u, bf):
 
 def wgr_BOLD_event_vector(N, matrix, thr, k, temporal_mask):
     """
-    Detect BOLD event.
-    event > thr & event < 3.1
+    Signal at a timepoint is counted as an event
+    when the following conditions are met:
+    Signal exceeds the threshold thr[0] and it is greater
+    than its k-neighbours on both two sides.
+    i.e. it is a local peak exceeding the threshold.
     """
     data = lil_matrix((1, N))
     matrix = matrix[:, np.newaxis]


### PR DESCRIPTION
`estimate_hrf` appended `np.inf` to `thr` in the FIR/sFIR branch, however only `thr[0]` is read. This and the "event < 3.1" line in the docstring originate from an alternative condition which was commented out in MATLAB's `rsHRF_find_event_vector.m`: the upper bound logic was never implemented in Python.

The docstring now addresses what the function truly performs: detect local peaks above the threshold, which is identical with MATLAB's implementation.